### PR TITLE
feat: allow additional labels on servicemonitor

### DIFF
--- a/deploy/charts/version-checker/templates/servicemonitor.yaml
+++ b/deploy/charts/version-checker/templates/servicemonitor.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "version-checker.name" . }}
   labels:
     app: {{ include "version-checker.name" . }}
+    {{- if .Values.serviceMonitor.additionalLabels }}
+{{- .Values.serviceMonitor.additionalLabels | toYaml | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/deploy/charts/version-checker/values.yaml
+++ b/deploy/charts/version-checker/values.yaml
@@ -47,3 +47,4 @@ prometheus:
 
 serviceMonitor:
   enabled: false
+  additionalLabels: {}


### PR DESCRIPTION
Hello,

In order to use prometheus-operator label selector, this PR allows the user to add their own label to the servicemonitor.