### PR TITLE
fix: do not warn when falling back to SHA comparison

### DIFF
--- a/pkg/controller/sync.go
+++ b/pkg/controller/sync.go
@@ -94,7 +94,7 @@ func (c *Controller) testContainerImage(ctx context.Context, log *logrus.Entry,
 		}
 
 		opts.UseSHA = true
-		log.Warnf("image using %q tag, comparing image SHA %q",
+		log.Debugf("image using %q tag, comparing image SHA %q",
 			statusTag, currentTag)
 	}
 


### PR DESCRIPTION
Fixes #10

Signed-off-by: Johan Fleury <jfleury@arcaik.net>