### PR TITLE
Better client parsing

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -11,6 +11,8 @@ import (
 	"github.com/jetstack/version-checker/pkg/client/quay"
 )
 
+// ImageClient represents a image registry client that can list available tags
+// for image URLs.
 type ImageClient interface {
 	// IsHost will return true if this client is appropriate for the given
 	// host.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,111 @@
+package client
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestFromImageURL(t *testing.T) {
+	handler, err := New(context.TODO(), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]struct {
+		url       string
+		expClient ImageClient
+		expHost   string
+		expPath   string
+	}{
+		"an empty image URL should be docker": {
+			url:       "",
+			expClient: handler.docker,
+			expHost:   "",
+			expPath:   "",
+		},
+		"single name should be docker": {
+			url:       "nginx",
+			expClient: handler.docker,
+			expHost:   "",
+			expPath:   "nginx",
+		},
+		"two names should be docker": {
+			url:       "joshvanl/version-checker",
+			expClient: handler.docker,
+			expHost:   "",
+			expPath:   "joshvanl/version-checker",
+		},
+		"docker.com should be docker": {
+			url:       "docker.com/joshvanl/version-checker",
+			expClient: handler.docker,
+			expHost:   "docker.com",
+			expPath:   "joshvanl/version-checker",
+		},
+		"docker.io should be docker": {
+			url:       "docker.io/joshvanl/version-checker",
+			expClient: handler.docker,
+			expHost:   "docker.io",
+			expPath:   "joshvanl/version-checker",
+		},
+		"docker.com with sub should be docker": {
+			url:       "foo.docker.com/joshvanl/version-checker",
+			expClient: handler.docker,
+			expHost:   "foo.docker.com",
+			expPath:   "joshvanl/version-checker",
+		},
+		"docker.io with sub should be docker": {
+			url:       "bar.docker.io/registry/joshvanl/version-checker",
+			expClient: handler.docker,
+			expHost:   "bar.docker.io",
+			expPath:   "registry/joshvanl/version-checker",
+		},
+
+		"gcr.io should be gcr": {
+			url:       "gcr.io/jetstack-cre/version-checker",
+			expClient: handler.gcr,
+			expHost:   "gcr.io",
+			expPath:   "jetstack-cre/version-checker",
+		},
+		"gcr.io with subdomain should be gcr": {
+			url:       "us.gcr.io/k8s-artifacts-prod/ingress-nginx/nginx",
+			expClient: handler.gcr,
+			expHost:   "us.gcr.io",
+			expPath:   "k8s-artifacts-prod/ingress-nginx/nginx",
+		},
+
+		"quay.io should be quay": {
+			url:       "quay.io/jetstack/version-checker",
+			expClient: handler.quay,
+			expHost:   "quay.io",
+			expPath:   "jetstack/version-checker",
+		},
+		"quay.io with subdomain should be quay": {
+			url:       "us.quay.io/k8s-artifacts-prod/ingress-nginx/nginx",
+			expClient: handler.quay,
+			expHost:   "us.quay.io",
+			expPath:   "k8s-artifacts-prod/ingress-nginx/nginx",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			client, host, path := handler.fromImageURL(test.url)
+
+			if client != test.expClient {
+				t.Errorf("unexpected client, exp=%v got=%v",
+					reflect.TypeOf(test.expClient), reflect.TypeOf(client))
+			}
+
+			if host != test.expHost {
+				t.Errorf("unexpected host, exp=%v got=%v",
+					test.expHost, host)
+			}
+
+			if path != test.expPath {
+				t.Errorf("unexpected path, exp=%s got=%s",
+					test.expPath, path)
+			}
+		})
+	}
+}

--- a/pkg/client/docker/docker.go
+++ b/pkg/client/docker/docker.go
@@ -14,9 +14,7 @@ import (
 )
 
 const (
-	repoURL        = "https://registry.hub.docker.com/v2/repositories/%s/tags"
-	imagePrefix    = "docker.io/"
-	imagePrefixHub = "registry.hub.docker.com/"
+	lookupURL = "https://registry.hub.docker.com/v2/repositories/%s/%s/tags"
 )
 
 type Options struct {
@@ -76,25 +74,8 @@ func New(ctx context.Context, opts Options) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) IsClient(imageURL string) bool {
-	return strings.HasPrefix(imageURL, imagePrefix) ||
-		strings.HasPrefix(imageURL, imagePrefixHub)
-}
-
-func (c *Client) Tags(ctx context.Context, imageURL string) ([]api.ImageTag, error) {
-	if strings.HasPrefix(imageURL, imagePrefix) {
-		imageURL = strings.TrimPrefix(imageURL, imagePrefix)
-	}
-
-	if strings.HasPrefix(imageURL, imagePrefixHub) {
-		imageURL = strings.TrimPrefix(imageURL, imagePrefixHub)
-	}
-
-	if len(strings.Split(imageURL, "/")) == 1 {
-		imageURL = fmt.Sprintf("library/%s", imageURL)
-	}
-
-	url := fmt.Sprintf(repoURL, imageURL)
+func (c *Client) Tags(ctx context.Context, _, repo, image string) ([]api.ImageTag, error) {
+	url := fmt.Sprintf(lookupURL, repo, image)
 
 	var tags []api.ImageTag
 	for url != "" {

--- a/pkg/client/docker/path.go
+++ b/pkg/client/docker/path.go
@@ -1,0 +1,25 @@
+package docker
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	reg = regexp.MustCompile(`(^(.*\.)?docker.com$)|(^(.*\.)?docker.io$)`)
+)
+
+func (c *Client) IsHost(host string) bool {
+	return reg.MatchString(host)
+}
+
+func (c *Client) RepoImageFromPath(path string) (string, string) {
+	split := strings.Split(path, "/")
+
+	lenSplit := len(split)
+	if lenSplit == 1 {
+		return "library", split[0]
+	}
+
+	return split[lenSplit-2], split[lenSplit-1]
+}

--- a/pkg/client/docker/path_test.go
+++ b/pkg/client/docker/path_test.go
@@ -1,0 +1,99 @@
+package docker
+
+import "testing"
+
+func TestIsHost(t *testing.T) {
+	tests := map[string]struct {
+		host  string
+		expIs bool
+	}{
+		"an empty host should be false": {
+			host:  "",
+			expIs: false,
+		},
+		"random string should be false": {
+			host:  "foobar",
+			expIs: false,
+		},
+		"random string with dots should be false": {
+			host:  "foobar.foo",
+			expIs: false,
+		},
+		"just docker.io should be true": {
+			host:  "docker.io",
+			expIs: true,
+		},
+		"just docker.com should be true": {
+			host:  "docker.com",
+			expIs: true,
+		},
+		"docker.com with random sub domains should be true": {
+			host:  "foo.bar.docker.com",
+			expIs: true,
+		},
+		"docker.io with random sub domains should be true": {
+			host:  "foo.bar.docker.io",
+			expIs: true,
+		},
+		"foodocker.com should be false": {
+			host:  "foodocker.com",
+			expIs: false,
+		},
+		"foodocker.io should be false": {
+			host:  "foodocker.io",
+			expIs: false,
+		},
+		"docker.comfoo should be false": {
+			host:  "docker.iofoo",
+			expIs: false,
+		},
+		"docker.iofoo should be false": {
+			host:  "ocker.iofoo",
+			expIs: false,
+		},
+	}
+
+	handler := new(Client)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if isHost := handler.IsHost(test.host); isHost != test.expIs {
+				t.Errorf("%s: unexpected IsHost, exp=%t got=%t",
+					test.host, test.expIs, isHost)
+			}
+		})
+	}
+}
+
+func TestRepoImage(t *testing.T) {
+	tests := map[string]struct {
+		path              string
+		expRepo, expImage string
+	}{
+		"single image should return libary": {
+			path:     "nginx",
+			expRepo:  "library",
+			expImage: "nginx",
+		},
+		"two segments to path should return both": {
+			path:     "joshvanl/version-checker",
+			expRepo:  "joshvanl",
+			expImage: "version-checker",
+		},
+		"multiple segments to path should return last two": {
+			path:     "registry/joshvanl/version-checker",
+			expRepo:  "joshvanl",
+			expImage: "version-checker",
+		},
+	}
+
+	handler := new(Client)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if repo, image := handler.RepoImageFromPath(test.path); !(repo == test.expRepo &&
+				image == test.expImage) {
+				t.Errorf("%s: unexpected repo/image, exp=%s/%s got=%s/%s",
+					test.path, test.expRepo, test.expImage, repo, image)
+			}
+		})
+	}
+}

--- a/pkg/client/gcr/path.go
+++ b/pkg/client/gcr/path.go
@@ -1,0 +1,24 @@
+package gcr
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	reg = regexp.MustCompile(`(^(.*\.)?gcr.io$)`)
+)
+
+func (c *Client) IsHost(host string) bool {
+	return reg.MatchString(host)
+}
+
+func (c *Client) RepoImageFromPath(path string) (string, string) {
+	lastIndex := strings.LastIndex(path, "/")
+
+	if lastIndex == -1 {
+		return "google-containers", path
+	}
+
+	return path[:lastIndex], path[lastIndex+1:]
+}

--- a/pkg/client/gcr/path_test.go
+++ b/pkg/client/gcr/path_test.go
@@ -1,0 +1,83 @@
+package gcr
+
+import "testing"
+
+func TestIsHost(t *testing.T) {
+	tests := map[string]struct {
+		host  string
+		expIs bool
+	}{
+		"an empty host should be false": {
+			host:  "",
+			expIs: false,
+		},
+		"random string should be false": {
+			host:  "foobar",
+			expIs: false,
+		},
+		"random string with dots should be false": {
+			host:  "foobar.foo",
+			expIs: false,
+		},
+		"just gcr.io should be true": {
+			host:  "gcr.io",
+			expIs: true,
+		},
+		"gcr.io with random sub domains should be true": {
+			host:  "k8s.gcr.io",
+			expIs: true,
+		},
+		"foodgcr.io should be false": {
+			host:  "foogcr.io",
+			expIs: false,
+		},
+		"gcr.iofoo should be false": {
+			host:  "gcr.iofoo",
+			expIs: false,
+		},
+	}
+
+	handler := new(Client)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if isHost := handler.IsHost(test.host); isHost != test.expIs {
+				t.Errorf("%s: unexpected IsHost, exp=%t got=%t",
+					test.host, test.expIs, isHost)
+			}
+		})
+	}
+}
+
+func TestRepoImage(t *testing.T) {
+	tests := map[string]struct {
+		path              string
+		expRepo, expImage string
+	}{
+		"single image should return google-containers": {
+			path:     "kube-scheduler",
+			expRepo:  "google-containers",
+			expImage: "kube-scheduler",
+		},
+		"two segments to path should return both": {
+			path:     "jetstack-cre/version-checker",
+			expRepo:  "jetstack-cre",
+			expImage: "version-checker",
+		},
+		"multiple segments to path should return all in repo, last segment image": {
+			path:     "k8s-artifacts-prod/ingress-nginx/nginx",
+			expRepo:  "k8s-artifacts-prod/ingress-nginx",
+			expImage: "nginx",
+		},
+	}
+
+	handler := new(Client)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if repo, image := handler.RepoImageFromPath(test.path); !(repo == test.expRepo &&
+				image == test.expImage) {
+				t.Errorf("%s: unexpected repo/image, exp=%s,%s got=%s,%s",
+					test.path, test.expRepo, test.expImage, repo, image)
+			}
+		})
+	}
+}

--- a/pkg/client/quay/path.go
+++ b/pkg/client/quay/path.go
@@ -1,0 +1,24 @@
+package quay
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	reg = regexp.MustCompile(`(^(.*\.)?quay.io$)`)
+)
+
+func (c *Client) IsHost(host string) bool {
+	return reg.MatchString(host)
+}
+
+func (c *Client) RepoImageFromPath(path string) (string, string) {
+	lastIndex := strings.LastIndex(path, "/")
+
+	if lastIndex == -1 {
+		return path, ""
+	}
+
+	return path[:lastIndex], path[lastIndex+1:]
+}

--- a/pkg/client/quay/path_test.go
+++ b/pkg/client/quay/path_test.go
@@ -1,0 +1,83 @@
+package quay
+
+import "testing"
+
+func TestIsHost(t *testing.T) {
+	tests := map[string]struct {
+		host  string
+		expIs bool
+	}{
+		"an empty host should be false": {
+			host:  "",
+			expIs: false,
+		},
+		"random string should be false": {
+			host:  "foobar",
+			expIs: false,
+		},
+		"random string with dots should be false": {
+			host:  "foobar.foo",
+			expIs: false,
+		},
+		"just quay.io should be true": {
+			host:  "quay.io",
+			expIs: true,
+		},
+		"quay.io with random sub domains should be true": {
+			host:  "k8s.quay.io",
+			expIs: true,
+		},
+		"foodquay.io should be false": {
+			host:  "fooquay.io",
+			expIs: false,
+		},
+		"quay.iofoo should be false": {
+			host:  "quay.iofoo",
+			expIs: false,
+		},
+	}
+
+	handler := new(Client)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if isHost := handler.IsHost(test.host); isHost != test.expIs {
+				t.Errorf("%s: unexpected IsHost, exp=%t got=%t",
+					test.host, test.expIs, isHost)
+			}
+		})
+	}
+}
+
+func TestRepoImage(t *testing.T) {
+	tests := map[string]struct {
+		path              string
+		expRepo, expImage string
+	}{
+		"single image should return empty image": {
+			path:     "version-checker",
+			expRepo:  "version-checker",
+			expImage: "",
+		},
+		"two segments to path should return both": {
+			path:     "jetstack/version-checker",
+			expRepo:  "jetstack",
+			expImage: "version-checker",
+		},
+		"multiple segments to path should return all in repo, last segment image": {
+			path:     "k8s-artifacts-prod/ingress-nginx/nginx",
+			expRepo:  "k8s-artifacts-prod/ingress-nginx",
+			expImage: "nginx",
+		},
+	}
+
+	handler := new(Client)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if repo, image := handler.RepoImageFromPath(test.path); !(repo == test.expRepo &&
+				image == test.expImage) {
+				t.Errorf("%s: unexpected repo/image, exp=%s,%s got=%s,%s",
+					test.path, test.expRepo, test.expImage, repo, image)
+			}
+		})
+	}
+}

--- a/pkg/client/quay/quay.go
+++ b/pkg/client/quay/quay.go
@@ -6,15 +6,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/jetstack/version-checker/pkg/api"
 )
 
 const (
-	repoURL     = "https://quay.io/api/v1/repository/%s/tag/"
-	imagePrefix = "quay.io/"
+	lookupURL = "https://quay.io/api/v1/repository/%s/%s/tag/"
 )
 
 type Options struct {
@@ -45,16 +43,8 @@ func New(opts Options) *Client {
 	}
 }
 
-func (c *Client) IsClient(imageURL string) bool {
-	return strings.HasPrefix(imageURL, imagePrefix)
-}
-
-func (c *Client) Tags(ctx context.Context, imageURL string) ([]api.ImageTag, error) {
-	if !c.IsClient(imageURL) {
-		return nil, fmt.Errorf("image does not have %q prefix: %s", imagePrefix, imageURL)
-	}
-
-	url := fmt.Sprintf(repoURL, strings.TrimPrefix(imageURL, imagePrefix))
+func (c *Client) Tags(ctx context.Context, _, repo, image string) ([]api.ImageTag, error) {
+	url := fmt.Sprintf(lookupURL, repo, image)
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {


### PR DESCRIPTION
This PR introduced better URL parsing for determining image clients to use.

This in turn fixes an issue with different sub-domains for gcr (e.g. `us.gcr.io/k8s-artifacts-prod/ingress-nginx/controller`).

We include units tests for these checks.

fixes #11 
/cc @johanfleury 