### PR TITLE
Handle sha+version, and Pod deletion/updating

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,4 +28,5 @@ require (
 	k8s.io/apimachinery v0.18.6
 	k8s.io/cli-runtime v0.18.6
 	k8s.io/client-go v0.18.6
+	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
 )

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -38,7 +38,7 @@ type Options struct {
 	PinMinor *int64 `json:"pin-minor,omitempty"`
 	PinPatch *int64 `json:"pin-patch,omitempty"`
 
-	RegexMatcher *regexp.Regexp
+	RegexMatcher *regexp.Regexp `json:"-"`
 }
 
 // ImageTag describes a container image tag.

--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -64,7 +63,7 @@ func (c *Controller) getLatestImage(ctx context.Context, log *logrus.Entry,
 	if !ok || cacheItem.timestamp.Add(c.cacheTimeout).Before(time.Now()) {
 		latestImage, err := c.versionGetter.LatestTagFromImage(ctx, opts, imageURL)
 		if err != nil {
-			return nil, fmt.Errorf("%q: %s", imageURL, err)
+			return nil, err
 		}
 
 		// Commit to the cache

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -134,11 +135,13 @@ func (c *Controller) processNextWorkItem(ctx context.Context, obj interface{}) e
 
 		// If the pod has been deleted, remove from metrics
 		for _, container := range pod.Spec.Containers {
-			imageURL, currentTag := urlAndTagFromImage(container.Image)
+			imageURL, currentTag, currentSHA := urlTagSHAFromImage(container.Image)
+
+			currentVersion := strings.Join([]string{currentTag, currentSHA}, "@")
 
 			c.log.Debugf("removing deleted container from metrics: %s/%s/%s: %s:%s",
 				pod.Namespace, pod.Name, container.Name, imageURL, currentTag)
-			c.metrics.RemoveImage(pod.Namespace, pod.Name, container.Name, imageURL, currentTag)
+			c.metrics.RemoveImage(pod.Namespace, pod.Name, container.Name, imageURL, currentVersion)
 		}
 
 		return nil

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
@@ -15,8 +14,10 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
 
 	"github.com/jetstack/version-checker/pkg/client"
+	"github.com/jetstack/version-checker/pkg/controller/scheduler"
 	"github.com/jetstack/version-checker/pkg/metrics"
 	"github.com/jetstack/version-checker/pkg/version"
 )
@@ -30,9 +31,10 @@ const (
 type Controller struct {
 	log *logrus.Entry
 
-	kubeClient kubernetes.Interface
-	podLister  corev1listers.PodLister
-	workqueue  workqueue.RateLimitingInterface
+	kubeClient         kubernetes.Interface
+	podLister          corev1listers.PodLister
+	workqueue          workqueue.RateLimitingInterface
+	scheduledWorkQueue scheduler.ScheduledWorkQueue
 
 	versionGetter *version.VersionGetter
 	metrics       *metrics.Metrics
@@ -52,15 +54,19 @@ func New(
 	log *logrus.Entry,
 	defaultTestAll bool,
 ) *Controller {
+	workqueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+	scheduledWorkQueue := scheduler.NewScheduledWorkQueue(clock.RealClock{}, workqueue.Add)
+
 	c := &Controller{
-		log:            log.WithField("module", "controller"),
-		kubeClient:     kubeClient,
-		workqueue:      workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		versionGetter:  version.New(log, imageClient, cacheTimeout),
-		metrics:        metrics,
-		cacheTimeout:   cacheTimeout,
-		imageCache:     make(map[string]imageCacheItem),
-		defaultTestAll: defaultTestAll,
+		log:                log.WithField("module", "controller"),
+		kubeClient:         kubeClient,
+		workqueue:          workqueue,
+		scheduledWorkQueue: scheduledWorkQueue,
+		versionGetter:      version.New(log, imageClient, cacheTimeout),
+		metrics:            metrics,
+		cacheTimeout:       cacheTimeout,
+		imageCache:         make(map[string]imageCacheItem),
+		defaultTestAll:     defaultTestAll,
 	}
 
 	return c
@@ -74,9 +80,14 @@ func (c *Controller) Run(ctx context.Context) error {
 	c.podLister = sharedInformerFactory.Core().V1().Pods().Lister()
 	podInformer := sharedInformerFactory.Core().V1().Pods().Informer()
 	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.workqueue.Add(obj) },
-		UpdateFunc: func(_, obj interface{}) { c.workqueue.Add(obj) },
-		DeleteFunc: func(obj interface{}) { c.workqueue.Add(obj) },
+		AddFunc: func(obj interface{}) { c.addObject(obj) },
+		UpdateFunc: func(old, new interface{}) {
+			if key, err := cache.MetaNamespaceKeyFunc(old); err == nil {
+				c.scheduledWorkQueue.Forget(key)
+			}
+			c.addObject(new)
+		},
+		DeleteFunc: func(obj interface{}) { c.addObject(obj) },
 	})
 
 	c.log.Info("starting control loop")
@@ -109,25 +120,38 @@ func (c *Controller) runWorker(ctx context.Context) {
 			return
 		}
 
-		if err := c.processNextWorkItem(ctx, obj); err != nil {
+		key, ok := obj.(string)
+		if !ok {
+			return
+		}
+
+		if err := c.processNextWorkItem(ctx, key); err != nil {
 			c.log.Error(err.Error())
 		}
 	}
 }
 
+func (c *Controller) addObject(obj interface{}) {
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		return
+	}
+	c.workqueue.AddRateLimited(key)
+}
+
 // processNextWorkItem will read a single work item off the workqueue and
 // attempt to process it, by calling the syncHandler.
-func (c *Controller) processNextWorkItem(ctx context.Context, obj interface{}) error {
-	defer c.workqueue.Done(obj)
+func (c *Controller) processNextWorkItem(ctx context.Context, key string) error {
+	defer c.workqueue.Done(key)
 
-	pod, ok := obj.(*corev1.Pod)
-	if !ok {
-		c.log.Errorf("non-pod type passed to sync: %+v", obj)
-		c.workqueue.Forget(obj)
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		c.log.Error(err, "invalid resource key")
 		return nil
 	}
 
-	if _, err := c.podLister.Pods(pod.Namespace).Get(pod.Name); err != nil {
+	pod, err := c.podLister.Pods(namespace).Get(name)
+	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
@@ -147,11 +171,13 @@ func (c *Controller) processNextWorkItem(ctx context.Context, obj interface{}) e
 	}
 
 	if err := c.sync(ctx, pod); err != nil {
-		c.workqueue.AddAfter(pod, time.Second*20)
+		c.scheduledWorkQueue.Add(pod, time.Second*20)
 		return fmt.Errorf("error syncing '%s/%s': %s, requeuing",
 			pod.Name, pod.Namespace, err)
 	}
 
-	c.workqueue.Forget(obj)
+	// Check the image tag again after the cache timeout.
+	c.scheduledWorkQueue.Add(key, c.cacheTimeout)
+
 	return nil
 }

--- a/pkg/controller/scheduler/scheduler.go
+++ b/pkg/controller/scheduler/scheduler.go
@@ -1,0 +1,91 @@
+package scheduler
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+// For mocking purposes.
+// This little bit of wrapping needs to be done because go doesn't do
+// covariance, but it does coerce *time.Timer into stoppable implicitly if we
+// write it out like so.
+var afterFunc = func(c clock.Clock, d time.Duration, f func()) stoppable {
+	t := c.NewTimer(d)
+
+	go func() {
+		defer t.Stop()
+		if ti := <-t.C(); ti == (time.Time{}) {
+			return
+		}
+		f()
+	}()
+
+	return t
+}
+
+// stoppable is the subset of time.Timer which we use, split out for mocking purposes
+type stoppable interface {
+	Stop() bool
+}
+
+// ProcessFunc is a function to process an item in the work queue.
+type ProcessFunc func(interface{})
+
+// ScheduledWorkQueue is an interface to describe a queue that will execute the
+// given ProcessFunc with the object given to Add once the time.Duration is up,
+// since the time of calling Add.
+type ScheduledWorkQueue interface {
+	// Add will add an item to this queue, executing the ProcessFunc after the
+	// Duration has come (since the time Add was called). If an existing Timer
+	// for obj already exists, the previous timer will be cancelled.
+	Add(interface{}, time.Duration)
+	// Forget will cancel the timer for the given object, if the timer exists.
+	Forget(interface{})
+}
+
+type scheduledWorkQueue struct {
+	processFunc ProcessFunc
+	clock       clock.Clock
+	work        map[interface{}]stoppable
+	workLock    sync.Mutex
+}
+
+// NewScheduledWorkQueue will create a new workqueue with the given processFunc
+func NewScheduledWorkQueue(clock clock.Clock, processFunc ProcessFunc) ScheduledWorkQueue {
+	return &scheduledWorkQueue{
+		processFunc: processFunc,
+		clock:       clock,
+		work:        make(map[interface{}]stoppable),
+		workLock:    sync.Mutex{},
+	}
+}
+
+// Add will add an item to this queue, executing the ProcessFunc after the
+// Duration has come (since the time Add was called). If an existing Timer for
+// obj already exists, the previous timer will be cancelled.
+func (s *scheduledWorkQueue) Add(obj interface{}, duration time.Duration) {
+	s.workLock.Lock()
+	defer s.workLock.Unlock()
+	s.forget(obj)
+	s.work[obj] = afterFunc(s.clock, duration, func() {
+		defer s.Forget(obj)
+		s.processFunc(obj)
+	})
+}
+
+// Forget will cancel the timer for the given object, if the timer exists.
+func (s *scheduledWorkQueue) Forget(obj interface{}) {
+	s.workLock.Lock()
+	defer s.workLock.Unlock()
+	s.forget(obj)
+}
+
+// forget cancels and removes an item. It *must* be called with the lock already held
+func (s *scheduledWorkQueue) forget(obj interface{}) {
+	if timer, ok := s.work[obj]; ok {
+		timer.Stop()
+		delete(s.work, obj)
+	}
+}

--- a/pkg/controller/scheduler/scheduler_test.go
+++ b/pkg/controller/scheduler/scheduler_test.go
@@ -1,0 +1,160 @@
+package scheduler
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+func TestAdd(t *testing.T) {
+	after := newMockAfter()
+	afterFunc = after.AfterFunc
+
+	var wg sync.WaitGroup
+	type testT struct {
+		obj      string
+		duration time.Duration
+	}
+	tests := []testT{
+		{"test500", time.Millisecond * 500},
+		{"test1000", time.Second * 1},
+		{"test3000", time.Second * 3},
+	}
+	for _, test := range tests {
+		wg.Add(1)
+		t.Run(test.obj, func(test testT) func(*testing.T) {
+			waitSubtest := make(chan struct{})
+			return func(t *testing.T) {
+				startTime := after.currentTime
+				queue := NewScheduledWorkQueue(clock.RealClock{}, func(obj interface{}) {
+					defer wg.Done()
+					durationEarly := test.duration - after.currentTime.Sub(startTime)
+
+					if durationEarly > 0 {
+						t.Errorf("got queue item %.2f seconds too early", float64(durationEarly)/float64(time.Second))
+					}
+					if obj != test.obj {
+						t.Errorf("expected obj '%+v' but got obj '%+v'", test.obj, obj)
+					}
+					waitSubtest <- struct{}{}
+				})
+				queue.Add(test.obj, test.duration)
+				after.warp(test.duration + time.Millisecond)
+				<-waitSubtest
+			}
+		}(test))
+	}
+
+	wg.Wait()
+}
+
+func TestForget(t *testing.T) {
+	after := newMockAfter()
+	afterFunc = after.AfterFunc
+
+	var wg sync.WaitGroup
+	type testT struct {
+		obj      string
+		duration time.Duration
+	}
+	tests := []testT{
+		{"test500", time.Millisecond * 500},
+		{"test1000", time.Second * 1},
+		{"test3000", time.Second * 3},
+	}
+	for _, test := range tests {
+		wg.Add(1)
+		t.Run(test.obj, func(test testT) func(*testing.T) {
+			return func(t *testing.T) {
+				defer wg.Done()
+				queue := NewScheduledWorkQueue(clock.RealClock{}, func(obj interface{}) {
+					t.Errorf("scheduled function should never be called")
+				})
+				queue.Add(test.obj, test.duration)
+				queue.Forget(test.obj)
+				after.warp(test.duration * 2)
+			}
+		}(test))
+	}
+
+	wg.Wait()
+}
+
+// TestConcurrentAdd checks that if we add the same item concurrently, it
+// doesn't end up hitting a data-race / leaking a timer.
+func TestConcurrentAdd(t *testing.T) {
+	after := newMockAfter()
+	afterFunc = after.AfterFunc
+	var wg sync.WaitGroup
+	queue := NewScheduledWorkQueue(clock.RealClock{}, func(obj interface{}) {
+		t.Fatalf("should not be called, but was called with %v", obj)
+	})
+
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func() {
+			queue.Add(1, 1*time.Second)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	queue.Forget(1)
+	after.warp(5 * time.Second)
+}
+
+type timerQueueItem struct {
+	f       func()
+	t       time.Time
+	run     bool
+	stopped bool
+}
+
+func (tq *timerQueueItem) Stop() bool {
+	stopped := tq.stopped
+	tq.stopped = true
+	return stopped
+}
+
+type mockAfter struct {
+	lock        *sync.Mutex
+	currentTime time.Time
+	queue       []*timerQueueItem
+}
+
+func newMockAfter() *mockAfter {
+	return &mockAfter{
+		queue: make([]*timerQueueItem, 0),
+		lock:  &sync.Mutex{},
+	}
+}
+
+func (m *mockAfter) AfterFunc(c clock.Clock, d time.Duration, f func()) stoppable {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	item := &timerQueueItem{
+		f: f,
+		t: m.currentTime.Add(d),
+	}
+	m.queue = append(m.queue, item)
+	return item
+}
+
+func (m *mockAfter) warp(d time.Duration) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.currentTime = m.currentTime.Add(d)
+	for _, item := range m.queue {
+		if item.run || item.stopped {
+			continue
+		}
+
+		if item.t.Before(m.currentTime) {
+			item.run = true
+			go item.f()
+		}
+	}
+}

--- a/pkg/controller/sync.go
+++ b/pkg/controller/sync.go
@@ -51,9 +51,6 @@ func (c *Controller) sync(ctx context.Context, pod *corev1.Pod) error {
 		}
 	}
 
-	// Check the image tag again after the cache timeout.
-	c.workqueue.AddAfter(pod, c.cacheTimeout)
-
 	if len(errs) > 0 {
 		return fmt.Errorf("failed to sync pod %s/%s: %s",
 			pod.Name, pod.Namespace, strings.Join(errs, ","))

--- a/pkg/controller/sync_test.go
+++ b/pkg/controller/sync_test.go
@@ -58,3 +58,41 @@ func TestURLAndTagFromImage(t *testing.T) {
 		})
 	}
 }
+
+func TestMetricsLabel(t *testing.T) {
+	tests := map[string]struct {
+		tag, sha  string
+		expOutput string
+	}{
+		"no input should output nothing": {
+			tag:       "",
+			sha:       "",
+			expOutput: "",
+		},
+		"just tag, make tag": {
+			tag:       "v1",
+			sha:       "",
+			expOutput: "v1",
+		},
+		"just sha, make sha": {
+			tag:       "",
+			sha:       "123",
+			expOutput: "123",
+		},
+		"tag + sha, make tag@sha": {
+			tag:       "v1",
+			sha:       "123",
+			expOutput: "v1@123",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			out := metricsLabel(test.tag, test.sha)
+			if out != test.expOutput {
+				t.Errorf("unexpected output for %q %q exp=%q got=%q",
+					test.tag, test.sha, test.expOutput, out)
+			}
+		})
+	}
+}

--- a/pkg/controller/sync_test.go
+++ b/pkg/controller/sync_test.go
@@ -1,0 +1,60 @@
+package controller
+
+import "testing"
+
+func TestURLAndTagFromImage(t *testing.T) {
+	tests := map[string]struct {
+		image             string
+		url, version, sha string
+	}{
+		"no version or sha, return just image": {
+			image:   "nginx",
+			url:     "nginx",
+			version: "",
+			sha:     "",
+		},
+		"version, return image and version": {
+			image:   "nginx:v1.0.0",
+			url:     "nginx",
+			version: "v1.0.0",
+			sha:     "",
+		},
+		"sha, return image and sha": {
+			image:   "nginx@sha:123",
+			url:     "nginx",
+			version: "",
+			sha:     "sha:123",
+		},
+		"version and sha, return image, version, and sha": {
+			image:   "nginx:v1.0.0@sha:123",
+			url:     "nginx",
+			version: "v1.0.0",
+			sha:     "sha:123",
+		},
+
+		"url in image, return sha": {
+			image:   "localhost:5000/version-checker@sha:123",
+			url:     "localhost:5000/version-checker",
+			version: "",
+			sha:     "sha:123",
+		},
+
+		"url in image with version, return sha and version": {
+			image:   "localhost:5000/version-checker:v0.1@sha:123",
+			url:     "localhost:5000/version-checker",
+			version: "v0.1",
+			sha:     "sha:123",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			url, version, sha := urlTagSHAFromImage(test.image)
+			if url != test.url || version != test.version || sha != test.sha {
+				t.Errorf("unexpected response, exp=%q,%q,%q got=%q,%q,%q",
+					test.url, test.version, test.sha,
+					url, version, sha)
+			}
+		})
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -91,7 +91,7 @@ func (m *Metrics) Run(servingAddress string) error {
 
 func (m *Metrics) AddImage(namespace, pod, container, imageURL string, currentVersion, latestVersion string) {
 	// Remove old image url/version if it exists
-	m.RemoveImage(namespace, pod, container, imageURL)
+	m.RemoveImage(namespace, pod, container)
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -113,7 +113,7 @@ func (m *Metrics) AddImage(namespace, pod, container, imageURL string, currentVe
 	}
 }
 
-func (m *Metrics) RemoveImage(namespace, pod, container, imageURL string) {
+func (m *Metrics) RemoveImage(namespace, pod, container string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -82,6 +82,9 @@ func (m *Metrics) Run(servingAddress string) error {
 }
 
 func (m *Metrics) AddImage(namespace, pod, container, imageURL string, currentImage, latestImage string) {
+	// Remove old image url/version if it exists
+	m.RemoveImage(namespace, pod, container, imageURL, currentImage)
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -24,8 +24,16 @@ type Metrics struct {
 	containerImageVersion *prometheus.GaugeVec
 	log                   *logrus.Entry
 
-	mu               sync.Mutex
-	latestImageLabel map[string]string
+	// container cache stores a cache of a container's current image, version,
+	// and the latest
+	containerCache map[string]cacheItem
+	mu             sync.Mutex
+}
+
+type cacheItem struct {
+	image          string
+	currentVersion string
+	latestVersion  string
 }
 
 func New(log *logrus.Entry) *Metrics {
@@ -47,7 +55,7 @@ func New(log *logrus.Entry) *Metrics {
 		log:                   log.WithField("module", "metrics"),
 		registry:              registry,
 		containerImageVersion: containerImageVersion,
-		latestImageLabel:      make(map[string]string),
+		containerCache:        make(map[string]cacheItem),
 	}
 }
 
@@ -81,51 +89,58 @@ func (m *Metrics) Run(servingAddress string) error {
 	return nil
 }
 
-func (m *Metrics) AddImage(namespace, pod, container, imageURL string, currentImage, latestImage string) {
+func (m *Metrics) AddImage(namespace, pod, container, imageURL string, currentVersion, latestVersion string) {
 	// Remove old image url/version if it exists
-	m.RemoveImage(namespace, pod, container, imageURL, currentImage)
+	m.RemoveImage(namespace, pod, container, imageURL)
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	isLatest := 0.0
-	if currentImage == latestImage {
+	if currentVersion == latestVersion {
 		isLatest = 1.0
 	}
 
 	m.containerImageVersion.With(
-		m.buildLabels(namespace, pod, container, imageURL, currentImage, latestImage),
+		m.buildLabels(namespace, pod, container, imageURL, currentVersion, latestVersion),
 	).Set(isLatest)
 
 	index := m.latestImageIndex(namespace, pod, container)
-	m.latestImageLabel[index] = latestImage
+	m.containerCache[index] = cacheItem{
+		image:          imageURL,
+		currentVersion: currentVersion,
+		latestVersion:  latestVersion,
+	}
 }
 
-func (m *Metrics) RemoveImage(namespace, pod, container, imageURL, currentImage string) {
+func (m *Metrics) RemoveImage(namespace, pod, container, imageURL string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	index := m.latestImageIndex(namespace, pod, container)
+	item, ok := m.containerCache[index]
+	if !ok {
+		return
+	}
+
 	m.containerImageVersion.Delete(
-		m.buildLabels(namespace, pod, container, imageURL, currentImage,
-			m.latestImageLabel[index],
-		),
+		m.buildLabels(namespace, pod, container, item.image, item.currentVersion, item.latestVersion),
 	)
-	delete(m.latestImageLabel, index)
+	delete(m.containerCache, index)
 }
 
 func (m *Metrics) latestImageIndex(namespace, pod, container string) string {
 	return strings.Join([]string{namespace, pod, container}, "")
 }
 
-func (m *Metrics) buildLabels(namespace, pod, container, imageURL, currentImage, latestImage string) prometheus.Labels {
+func (m *Metrics) buildLabels(namespace, pod, container, imageURL, currentVersion, latestVersion string) prometheus.Labels {
 	return prometheus.Labels{
 		"namespace":       namespace,
 		"pod":             pod,
 		"container":       container,
 		"image":           imageURL,
-		"current_version": currentImage,
-		"latest_version":  latestImage,
+		"current_version": currentVersion,
+		"latest_version":  latestVersion,
 	}
 }
 

--- a/pkg/version/errors/errors.go
+++ b/pkg/version/errors/errors.go
@@ -1,0 +1,23 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+type ErrorVersionNotFound struct {
+	error
+}
+
+func NewVersionErrorNotFound(format string, a ...interface{}) *ErrorVersionNotFound {
+	if len(a) == 0 {
+		return &ErrorVersionNotFound{errors.New(format)}
+	}
+
+	return &ErrorVersionNotFound{fmt.Errorf(format, a...)}
+}
+
+func IsNoVersionFound(err error) bool {
+	var notFound *ErrorVersionNotFound
+	return errors.As(err, &notFound)
+}

--- a/pkg/version/semver/semver.go
+++ b/pkg/version/semver/semver.go
@@ -90,6 +90,11 @@ func (s *SemVer) LessThan(other *SemVer) bool {
 	return false
 }
 
+// Equal will return true if the given semver is equal.
+func (s *SemVer) Equal(other *SemVer) bool {
+	return s.original == other.original
+}
+
 // HasMetaData returns whether this SemVer has metadata. MetaData is defined
 // as a tag containing anything after the patch digit.
 // e.g. v1.0.1-gke.3, v1.0.1-alpha.0, v1.2.3.4


### PR DESCRIPTION
This PR fixes our handling of images that use a semver version tag and sha as the tag.

We also fix up some issues with pods being updated in place, or deleted, and correctly handling that in the metrics.

Pods are now correctly re-scheduled.

fixes #17 