### PR TITLE
Adds support for ECR

### DIFF
--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -19,35 +18,7 @@ import (
 
 const (
 	helpOutput = "Kubernetes utility for exposing used image versions compared to the latest version, as metrics."
-
-	envPrefix = "VERSION_CHECKER"
-
-	envACRUsername     = "ACR_USERNAME"
-	envACRPassword     = "ACR_PASSWORD"
-	envACRRefreshToken = "ACR_REFRESH_TOKEN"
-
-	envDockerUsername = "DOCKER_USERNAME"
-	envDockerPassword = "DOCKER_PASSWORD"
-	envDockerJWT      = "DOCKER_TOKEN"
-
-	envGCRAccessToken = "GCR_TOKEN"
-
-	envQuayToken = "QUAY_TOKEN"
-
-	envSelfhostedUsername = "SELFHOSTED_USERNAME"
-	envSelfhostedPassword = "SELFHOSTED_PASSWORD"
-	envSelfhostedBearer   = "SELFHOSTED_TOKEN"
 )
-
-// Options is a struct to hold options for the version-checker
-type Options struct {
-	MetricsServingAddress string
-	DefaultTestAll        bool
-	CacheTimeout          time.Duration
-	LogLevel              string
-
-	Client client.Options
-}
 
 func NewCommand(ctx context.Context) *cobra.Command {
 	opts := new(Options)
@@ -115,144 +86,4 @@ func NewCommand(ctx context.Context) *cobra.Command {
 	opts.addFlags(cmd)
 
 	return cmd
-}
-
-func (o *Options) addFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVarP(&o.MetricsServingAddress,
-		"metrics-serving-address", "m", "0.0.0.0:8080",
-		"Address to serve metrics on at the /metrics path.")
-
-	cmd.PersistentFlags().BoolVarP(&o.DefaultTestAll,
-		"test-all-containers", "a", false,
-		`If enable, all containers will be tested, unless they have the annotation `+
-			`"enable.version-checker/${my-container}=false".`)
-
-	cmd.PersistentFlags().DurationVarP(&o.CacheTimeout,
-		"image-cache-timeout", "c", time.Minute*30,
-		"The time for an image in the cache to be considered fresh. Images will be "+
-			"checked at this interval.")
-
-	cmd.PersistentFlags().StringVarP(&o.LogLevel,
-		"log-level", "v", "info",
-		"Log level (debug, info, warn, error, fatal, panic).")
-
-	cmd.PersistentFlags().StringVar(&o.Client.ACR.Username,
-		"acr-username", "",
-		fmt.Sprintf(
-			"Username to authenticate with azure container registry (%s_%s).",
-			envPrefix, envACRUsername,
-		))
-	cmd.PersistentFlags().StringVar(&o.Client.ACR.Password,
-		"acr-password", "",
-		fmt.Sprintf(
-			"Password to authenticate with azure container registry (%s_%s).",
-			envPrefix, envACRPassword,
-		))
-	cmd.PersistentFlags().StringVar(&o.Client.ACR.RefreshToken,
-		"acr-refresh-token", "",
-		fmt.Sprintf(
-			"Refresh token to authenticate with azure container registry. Cannot be used with "+
-				"username/password (%s_%s).",
-			envPrefix, envACRRefreshToken,
-		))
-
-	cmd.PersistentFlags().StringVar(&o.Client.Docker.Username,
-		"docker-username", "",
-		fmt.Sprintf(
-			"Username to authenticate with docker registry (%s_%s).",
-			envPrefix, envDockerUsername,
-		))
-	cmd.PersistentFlags().StringVar(&o.Client.Docker.Password,
-		"docker-password", "",
-		fmt.Sprintf(
-			"Password to authenticate with docker registry (%s_%s).",
-			envPrefix, envDockerPassword,
-		))
-	cmd.PersistentFlags().StringVar(&o.Client.Docker.JWT,
-		"docker-token", "",
-		fmt.Sprintf(
-			"Token to authenticate with docker registry. Cannot be used with "+
-				"username/password (%s_%s).",
-			envPrefix, envDockerJWT,
-		))
-	cmd.PersistentFlags().StringVar(&o.Client.Docker.LoginURL,
-		"docker-login-url", "https://hub.docker.com/v2/users/login/",
-		"URL to login into docker using username/password.")
-
-	cmd.PersistentFlags().StringVar(&o.Client.GCR.Token,
-		"gcr-token", "",
-		fmt.Sprintf(
-			"Access token for read access to private GCR registries (%s_%s).",
-			envPrefix, envGCRAccessToken,
-		))
-
-	cmd.PersistentFlags().StringVar(&o.Client.Quay.Token,
-		"quay-token", "",
-		fmt.Sprintf(
-			"Access token for read access to private Quay registries (%s_%s).",
-			envPrefix, envQuayToken,
-		))
-
-	cmd.PersistentFlags().StringVar(&o.Client.Selfhosted.Username,
-		"selfhosted-username", "",
-		fmt.Sprintf(
-			"Username is authenticate with a selfhosted registry (%s_%s).",
-			envPrefix, envSelfhostedUsername,
-		))
-	cmd.PersistentFlags().StringVar(&o.Client.Selfhosted.Password,
-		"selfhosted-password", "",
-		fmt.Sprintf(
-			"Password is authenticate with a selfhosted registry (%s_%s).",
-			envPrefix, envSelfhostedPassword,
-		))
-	cmd.PersistentFlags().StringVar(&o.Client.Selfhosted.Bearer,
-		"selfhosted-token", "",
-		fmt.Sprintf(
-			"Token to authenticate to a selfhosted registry. Cannot be used with "+
-				"username/password (%s_%s).",
-			envPrefix, envSelfhostedBearer,
-		))
-	cmd.PersistentFlags().StringVar(&o.Client.Selfhosted.URL,
-		"selfhosted-registry-url", "",
-		"URL of the selfhosted registry.")
-}
-
-func (o *Options) checkEnv() {
-	if len(o.Client.ACR.Username) == 0 {
-		o.Client.ACR.Username = os.Getenv(envPrefix + "_" + envACRUsername)
-	}
-	if len(o.Client.ACR.Password) == 0 {
-		o.Client.ACR.Password = os.Getenv(envPrefix + "_" + envACRPassword)
-	}
-	if len(o.Client.ACR.RefreshToken) == 0 {
-		o.Client.ACR.RefreshToken = os.Getenv(envPrefix + "_" + envACRRefreshToken)
-	}
-
-	if len(o.Client.Docker.Username) == 0 {
-		o.Client.Docker.Username = os.Getenv(envPrefix + "_" + envDockerUsername)
-	}
-	if len(o.Client.Docker.Password) == 0 {
-		o.Client.Docker.Password = os.Getenv(envPrefix + "_" + envDockerPassword)
-	}
-	if len(o.Client.Docker.JWT) == 0 {
-		o.Client.Docker.JWT = os.Getenv(envPrefix + "_" + envDockerJWT)
-	}
-
-	if len(o.Client.GCR.Token) == 0 {
-		o.Client.GCR.Token = os.Getenv(envPrefix + "_" + envGCRAccessToken)
-	}
-
-	if len(o.Client.Quay.Token) == 0 {
-		o.Client.Quay.Token = os.Getenv(envPrefix + "_" + envQuayToken)
-	}
-
-	if len(o.Client.Selfhosted.Username) == 0 {
-		o.Client.Selfhosted.Username = os.Getenv(envPrefix + "_" + envSelfhostedUsername)
-	}
-	if len(o.Client.Selfhosted.Password) == 0 {
-		o.Client.Selfhosted.Password = os.Getenv(envPrefix + "_" + envSelfhostedPassword)
-	}
-	if len(o.Client.Selfhosted.Bearer) == 0 {
-		o.Client.Selfhosted.Bearer = os.Getenv(envPrefix + "_" + envSelfhostedBearer)
-	}
 }

--- a/cmd/app/options.go
+++ b/cmd/app/options.go
@@ -1,0 +1,235 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jetstack/version-checker/pkg/client"
+)
+
+const (
+	envPrefix = "VERSION_CHECKER"
+
+	envACRUsername     = "ACR_USERNAME"
+	envACRPassword     = "ACR_PASSWORD"
+	envACRRefreshToken = "ACR_REFRESH_TOKEN"
+
+	envECRAccessKeyID     = "ECR_ACCESS_KEY_ID"
+	envECRSecretAccessKey = "ECR_SECRET_ACCESS_KEY"
+	envECRSessionToken    = "ECR_SESSION_TOKEN"
+
+	envDockerUsername = "DOCKER_USERNAME"
+	envDockerPassword = "DOCKER_PASSWORD"
+	envDockerJWT      = "DOCKER_TOKEN"
+
+	envGCRAccessToken = "GCR_TOKEN"
+
+	envQuayToken = "QUAY_TOKEN"
+
+	envSelfhostedUsername = "SELFHOSTED_USERNAME"
+	envSelfhostedPassword = "SELFHOSTED_PASSWORD"
+	envSelfhostedBearer   = "SELFHOSTED_TOKEN"
+)
+
+// Options is a struct to hold options for the version-checker
+type Options struct {
+	MetricsServingAddress string
+	DefaultTestAll        bool
+	CacheTimeout          time.Duration
+	LogLevel              string
+
+	Client client.Options
+}
+
+func (o *Options) addFlags(cmd *cobra.Command) {
+	/// App flags
+	cmd.PersistentFlags().StringVarP(&o.MetricsServingAddress,
+		"metrics-serving-address", "m", "0.0.0.0:8080",
+		"Address to serve metrics on at the /metrics path.")
+
+	cmd.PersistentFlags().BoolVarP(&o.DefaultTestAll,
+		"test-all-containers", "a", false,
+		`If enable, all containers will be tested, unless they have the annotation `+
+			`"enable.version-checker/${my-container}=false".`)
+
+	cmd.PersistentFlags().DurationVarP(&o.CacheTimeout,
+		"image-cache-timeout", "c", time.Minute*30,
+		"The time for an image in the cache to be considered fresh. Images will be "+
+			"checked at this interval.")
+
+	cmd.PersistentFlags().StringVarP(&o.LogLevel,
+		"log-level", "v", "info",
+		"Log level (debug, info, warn, error, fatal, panic).")
+	///
+
+	/// ACR
+	cmd.PersistentFlags().StringVar(&o.Client.ACR.Username,
+		"acr-username", "",
+		fmt.Sprintf(
+			"Username to authenticate with azure container registry (%s_%s).",
+			envPrefix, envACRUsername,
+		))
+	cmd.PersistentFlags().StringVar(&o.Client.ACR.Password,
+		"acr-password", "",
+		fmt.Sprintf(
+			"Password to authenticate with azure container registry (%s_%s).",
+			envPrefix, envACRPassword,
+		))
+	cmd.PersistentFlags().StringVar(&o.Client.ACR.RefreshToken,
+		"acr-refresh-token", "",
+		fmt.Sprintf(
+			"Refresh token to authenticate with azure container registry. Cannot be used with "+
+				"username/password (%s_%s).",
+			envPrefix, envACRRefreshToken,
+		))
+	///
+
+	/// ECR
+	cmd.PersistentFlags().StringVar(&o.Client.GCR.Token,
+		"ecr-access-key-id", "",
+		fmt.Sprintf(
+			"ECR access key ID for read access to private registries (%s_%s).",
+			envPrefix, envECRAccessKeyID,
+		))
+	cmd.PersistentFlags().StringVar(&o.Client.GCR.Token,
+		"ecr-secret-access-key", "",
+		fmt.Sprintf(
+			"ECR secret access key for read access to private registries (%s_%s).",
+			envPrefix, envECRSecretAccessKey,
+		))
+	cmd.PersistentFlags().StringVar(&o.Client.GCR.Token,
+		"ecr-session-token", "",
+		fmt.Sprintf(
+			"ECR session token for read access to private registries (%s_%s).",
+			envPrefix, envECRSessionToken,
+		))
+	///
+
+	/// GCR
+	cmd.PersistentFlags().StringVar(&o.Client.GCR.Token,
+		"gcr-token", "",
+		fmt.Sprintf(
+			"Access token for read access to private GCR registries (%s_%s).",
+			envPrefix, envGCRAccessToken,
+		))
+	///
+
+	/// Docker
+	cmd.PersistentFlags().StringVar(&o.Client.Docker.Username,
+		"docker-username", "",
+		fmt.Sprintf(
+			"Username is authenticate with docker registry (%s_%s).",
+			envPrefix, envDockerUsername,
+		))
+	cmd.PersistentFlags().StringVar(&o.Client.Docker.Password,
+		"docker-password", "",
+		fmt.Sprintf(
+			"Password is authenticate with docker registry (%s_%s).",
+			envPrefix, envDockerPassword,
+		))
+	cmd.PersistentFlags().StringVar(&o.Client.Docker.JWT,
+		"docker-token", "",
+		fmt.Sprintf(
+			"Token is authenticate with docker registry. Cannot be used with "+
+				"username/password (%s_%s).",
+			envPrefix, envDockerJWT,
+		))
+	cmd.PersistentFlags().StringVar(&o.Client.Docker.LoginURL,
+		"docker-login-url", "https://hub.docker.com/v2/users/login/",
+		"URL to login into docker using username/password.")
+	///
+
+	/// Quay
+	cmd.PersistentFlags().StringVar(&o.Client.Quay.Token,
+		"quay-token", "",
+		fmt.Sprintf(
+			"Access token for read access to private Quay registries (%s_%s).",
+			envPrefix, envQuayToken,
+		))
+	///
+
+	/// Selfhosted
+	cmd.PersistentFlags().StringVar(&o.Client.Selfhosted.Username,
+		"selfhosted-username", "",
+		fmt.Sprintf(
+			"Username is authenticate with a selfhosted registry (%s_%s).",
+			envPrefix, envSelfhostedUsername,
+		))
+	cmd.PersistentFlags().StringVar(&o.Client.Selfhosted.Password,
+		"selfhosted-password", "",
+		fmt.Sprintf(
+			"Password is authenticate with a selfhosted registry (%s_%s).",
+			envPrefix, envSelfhostedPassword,
+		))
+	cmd.PersistentFlags().StringVar(&o.Client.Selfhosted.Bearer,
+		"selfhosted-token", "",
+		fmt.Sprintf(
+			"Token to authenticate to a selfhosted registry. Cannot be used with "+
+				"username/password (%s_%s).",
+			envPrefix, envSelfhostedBearer,
+		))
+	cmd.PersistentFlags().StringVar(&o.Client.Selfhosted.URL,
+		"selfhosted-registry-url", "",
+		"URL of the selfhosted registry.")
+	///
+}
+
+func (o *Options) checkEnv() {
+
+	// ACR
+	if len(o.Client.ACR.Username) == 0 {
+		o.Client.ACR.Username = os.Getenv(envPrefix + "_" + envACRUsername)
+	}
+	if len(o.Client.ACR.Password) == 0 {
+		o.Client.ACR.Password = os.Getenv(envPrefix + "_" + envACRPassword)
+	}
+	if len(o.Client.ACR.RefreshToken) == 0 {
+		o.Client.ACR.RefreshToken = os.Getenv(envPrefix + "_" + envACRRefreshToken)
+	}
+
+	// ECR
+	if len(o.Client.ECR.AccessKeyID) == 0 {
+		o.Client.ECR.AccessKeyID = os.Getenv(envPrefix + "_" + envECRAccessKeyID)
+	}
+	if len(o.Client.ECR.SecretAccessKey) == 0 {
+		o.Client.ECR.SecretAccessKey = os.Getenv(envPrefix + "_" + envECRSecretAccessKey)
+	}
+	if len(o.Client.ECR.SessionToken) == 0 {
+		o.Client.ECR.SessionToken = os.Getenv(envPrefix + "_" + envECRSessionToken)
+	}
+
+	// Docker
+	if len(o.Client.Docker.Username) == 0 {
+		o.Client.Docker.Username = os.Getenv(envPrefix + "_" + envDockerUsername)
+	}
+	if len(o.Client.Docker.Password) == 0 {
+		o.Client.Docker.Password = os.Getenv(envPrefix + "_" + envDockerPassword)
+	}
+	if len(o.Client.Docker.JWT) == 0 {
+		o.Client.Docker.JWT = os.Getenv(envPrefix + "_" + envDockerJWT)
+	}
+
+	// GCR
+	if len(o.Client.GCR.Token) == 0 {
+		o.Client.GCR.Token = os.Getenv(envPrefix + "_" + envGCRAccessToken)
+	}
+
+	// Quay
+	if len(o.Client.Quay.Token) == 0 {
+		o.Client.Quay.Token = os.Getenv(envPrefix + "_" + envQuayToken)
+	}
+
+	// Selfhosted
+	if len(o.Client.Selfhosted.Username) == 0 {
+		o.Client.Selfhosted.Username = os.Getenv(envPrefix + "_" + envSelfhostedUsername)
+	}
+	if len(o.Client.Selfhosted.Password) == 0 {
+		o.Client.Selfhosted.Password = os.Getenv(envPrefix + "_" + envSelfhostedPassword)
+	}
+	if len(o.Client.Selfhosted.Bearer) == 0 {
+		o.Client.Selfhosted.Bearer = os.Getenv(envPrefix + "_" + envSelfhostedBearer)
+	}
+}

--- a/deploy/charts/version-checker/templates/deployment.yaml
+++ b/deploy/charts/version-checker/templates/deployment.yaml
@@ -1,5 +1,5 @@
 {{- $secretEnabled := false }}
-{{- if or  .Values.docker.token .Values.docker.username .Values.docker.password .Values.gcr.token  .Values.quay.token .Values.acr.refreshToken .Values.acr.username .Values.acr.password  }}
+{{- if or .Values.acr.refreshToken .Values.acr.username .Values.acr.password .Values.docker.token .Values.docker.username .Values.docker.password .Values.ecr.accessKeyID .Values.ecr.secretAccessKey .Values.ecr.sessionToken .Values.gcr.token .Values.quay.token .Values.selfhosted.token .Values.selfhosted.username .Values.selfhosted.password }}
 {{- $secretEnabled = true }}
 {{- end }}
 apiVersion: apps/v1
@@ -41,27 +41,8 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         env:
-        {{- if .Values.docker.token }}
-        - name: VERSION_CHECKER_DOCKER_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "version-checker.name" . }}
-              key: docker.token
-        {{- end }}
-        {{- if .Values.docker.username }}
-        - name: VERSION_CHECKER_DOCKER_USERNAME
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "version-checker.name" . }}
-              key: docker.username
-        {{- end }}
-        {{- if .Values.docker.password }}
-        - name: VERSION_CHECKER_DOCKER_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "version-checker.name" . }}
-              key: docker.password
-        {{- end }}
+
+        # ACR
         {{- if .Values.acr.refreshToken }}
         - name: VERSION_CHECKER_ACR_REFRESH_TOKEN
           valueFrom:
@@ -83,6 +64,54 @@ spec:
               name: {{ include "version-checker.name" . }}
               key: acr.password
         {{- end }}
+
+        # ECR
+        {{- if .Values.ecr.accessKeyID }}
+        - name: VERSION_CHECKER_ECR_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "version-checker.name" . }}
+              key: ecr.accessKeyID
+        {{- end }}
+        {{- if .Values.ecr.secretAccessKey }}
+        - name: VERSION_CHECKER_ECR_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "version-checker.name" . }}
+              key: ecr.secretAccessKey
+        {{- end }}
+        {{- if .Values.ecr.sessionToken }}
+        - name: VERSION_CHECKER_ECR_SESSION_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "version-checker.name" . }}
+              key: ecr.sessionToken
+        {{- end }}
+
+        # Docker
+        {{- if .Values.docker.token }}
+        - name: VERSION_CHECKER_DOCKER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "version-checker.name" . }}
+              key: docker.token
+        {{- end }}
+        {{- if .Values.docker.username }}
+        - name: VERSION_CHECKER_DOCKER_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "version-checker.name" . }}
+              key: docker.username
+        {{- end }}
+        {{- if .Values.docker.password }}
+        - name: VERSION_CHECKER_DOCKER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "version-checker.name" . }}
+              key: docker.password
+        {{- end }}
+
+        # GCR
         {{- if .Values.gcr.token }}
         - name: VERSION_CHECKER_GCR_TOKEN
           valueFrom:
@@ -90,6 +119,8 @@ spec:
               name: {{ include "version-checker.name" . }}
               key: gcr.token
         {{- end }}
+
+        # Quay
         {{- if .Values.quay.token }}
         - name: VERSION_CHECKER_QUAY_TOKEN
           valueFrom:
@@ -97,13 +128,8 @@ spec:
               name: {{ include "version-checker.name" . }}
               key: quay.token
         {{- end }}
-        {{- if .Values.selfhosted.token }}
-        - name: VERSION_CHECKER_SELFHOSTED_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "version-checker.name" . }}
-              key: selfhosted.token
-        {{- end }}     
+
+        # Selfhosted
         {{- if .Values.selfhosted.username }}
         - name: VERSION_CHECKER_SELFHOSTED_USERNAME
           valueFrom:
@@ -117,7 +143,15 @@ spec:
             secretKeyRef:
               name: {{ include "version-checker.name" . }}
               key: selfhosted.password
-        {{- end }}           
+        {{- end }}
+        {{- if .Values.selfhosted.token }}
+        - name: VERSION_CHECKER_SELFHOSTED_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "version-checker.name" . }}
+              key: selfhosted.token
+        {{- end }}
+
       volumes:
         {{- if $secretEnabled }}
         - name: {{ include "version-checker.name" . }}

--- a/deploy/charts/version-checker/templates/secret.yaml
+++ b/deploy/charts/version-checker/templates/secret.yaml
@@ -1,15 +1,7 @@
-{{- if or  .Values.docker.token .Values.docker.username .Values.docker.password .Values.gcr.token  .Values.quay.token .Values.acr.refreshToken .Values.acr.username .Values.acr.password }}
+{{- if or .Values.acr.refreshToken .Values.acr.username .Values.acr.password .Values.docker.token .Values.ecr.accessKeyID .Values.ecr.secretAccessKey .Values.ecr.sessionToken .Values.docker.username .Values.docker.password .Values.gcr.token .Values.quay.token .Values.selfhosted.token .Values.selfhosted.username .Values.selfhosted.password }}
 apiVersion: v1
 data:
-  {{- if .Values.docker.token }}
-  docker.token: {{.Values.docker.token | b64enc }}
-  {{- end}}
-  {{- if .Values.docker.username }}
-  docker.username: {{.Values.docker.username | b64enc }}
-  {{- end}}
-  {{- if .Values.docker.password }}
-  docker.password: {{.Values.docker.password | b64enc }}
-  {{- end}}
+  # ACR
   {{- if .Values.acr.refreshToken }}
   acr.refreshToken: {{.Values.acr.refreshToken | b64enc }}
   {{- end}}
@@ -19,13 +11,41 @@ data:
   {{- if .Values.acr.password }}
   acr.password: {{.Values.acr.password | b64enc }}
   {{- end}}
+
+  # Docker
+  {{- if .Values.docker.token }}
+  docker.token: {{.Values.docker.token | b64enc }}
+  {{- end}}
+  {{- if .Values.docker.username }}
+  docker.username: {{.Values.docker.username | b64enc }}
+  {{- end}}
+  {{- if .Values.docker.password }}
+  docker.password: {{.Values.docker.password | b64enc }}
+  {{- end}}
+
+  # ECR
+  {{- if .Values.ecr.accessKeyID }}
+  ecr.accessKeyID: {{ .Values.ecr.accessKeyID | b64enc }}
+  {{- end}}
+  {{- if .Values.ecr.secretAccessKey }}
+  ecr.secretAccessKey: {{ .Values.ecr.secretAccessKey | b64enc }}
+  {{- end}}
+  {{- if .Values.ecr.sessionToken }}
+  ecr.sessionToken: {{ .Values.ecr.sessionToken | b64enc }}
+  {{- end}}
+
+  # GCR
   {{- if .Values.gcr.token }}
   gcr.token: {{ .Values.gcr.token | b64enc }}
   {{- end}}
+
+  # Quay
   {{- if .Values.quay.token }}
   quay.token: {{ .Values.quay.token | b64enc }}
   {{- end}}
   {{- if .Values.selfhosted.token }}
+
+  # Selfhosted
   selfhosted.token: {{.Values.selfhosted.token | b64enc }}
   {{- end}}
   {{- if .Values.selfhosted.username }}
@@ -33,7 +53,8 @@ data:
   {{- end}}
   {{- if .Values.selfhosted.password }}
   selfhosted.password: {{.Values.selfhosted.password | b64enc }}
-  {{- end}}  
+  {{- end}}
+
 kind: Secret
 metadata:
   name: {{ include "version-checker.name" . }}

--- a/deploy/charts/version-checker/values.yaml
+++ b/deploy/charts/version-checker/values.yaml
@@ -18,16 +18,21 @@ versionChecker:
   metricsServingAddress: 0.0.0.0:8080
   testAllContainers: true # don't require the enable.version-checker.io annotation
 
+acr:
+  username:
+  password:
+  refreshToken:
+
 docker:
   loginURL: https://hub.docker.com/v2/users/login/
   username:
   password:
   token:
 
-acr:
-  username:
-  password:
-  refreshToken:
+ecr:
+  accessKeyID:
+  secretAccessKey:
+  sessionToken:
 
 gcr:
   token:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go v0.57.0 // indirect
 	github.com/Azure/go-autorest/autorest v0.10.2
 	github.com/Azure/go-autorest/autorest/adal v0.8.3
+	github.com/aws/aws-sdk-go v1.34.10
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
 	github.com/google/go-cmp v0.4.1 // indirect
@@ -14,11 +15,9 @@ require (
 	github.com/imdario/mergo v0.3.9 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/pkg/errors v0.9.0 // indirect
 	github.com/prometheus/client_golang v1.7.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v0.0.5
-	github.com/stretchr/testify v1.5.1 // indirect
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37 // indirect
 	golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2 // indirect
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/aws/aws-sdk-go v1.34.10 h1:VU78gcf/3wA4HNEDCHidK738l7K0Bals4SJnfnvXOtY=
+github.com/aws/aws-sdk-go v1.34.10/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -116,6 +118,7 @@ github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dp
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5 h1:lTz6Ys4CmqqCQmZPBlbQENR1/GucA2bzYTE12Pw4tFY=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
@@ -188,6 +191,8 @@ github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
+github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
@@ -242,8 +247,8 @@ github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+v
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.0 h1:J8lpUdobwIeCI7OiSxHqEwJUKvJwicL5+3v1oe2Yb4k=
-github.com/pkg/errors v0.9.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jetstack/version-checker/pkg/api"
 	"github.com/jetstack/version-checker/pkg/client/acr"
 	"github.com/jetstack/version-checker/pkg/client/docker"
+	"github.com/jetstack/version-checker/pkg/client/ecr"
 	"github.com/jetstack/version-checker/pkg/client/gcr"
 	"github.com/jetstack/version-checker/pkg/client/quay"
 	"github.com/jetstack/version-checker/pkg/client/selfhosted"
@@ -35,6 +36,7 @@ type ImageClient interface {
 // URLs.
 type Client struct {
 	acr        *acr.Client
+	ecr        *ecr.Client
 	gcr        *gcr.Client
 	docker     *docker.Client
 	quay       *quay.Client
@@ -44,6 +46,7 @@ type Client struct {
 // Options used to configure client authentication.
 type Options struct {
 	ACR        acr.Options
+	ECR        ecr.Options
 	GCR        gcr.Options
 	Docker     docker.Options
 	Quay       quay.Options
@@ -67,6 +70,7 @@ func New(ctx context.Context, log *logrus.Entry, opts Options) (*Client, error) 
 
 	return &Client{
 		acr:        acrClient,
+		ecr:        ecr.New(opts.ECR),
 		docker:     dockerClient,
 		gcr:        gcr.New(opts.GCR),
 		quay:       quay.New(opts.Quay),
@@ -96,6 +100,8 @@ func (c *Client) fromImageURL(imageURL string) (ImageClient, string, string) {
 		return c.acr, host, path
 	case c.docker.IsHost(host):
 		return c.docker, host, path
+	case c.ecr.IsHost(host):
+		return c.ecr, host, path
 	case c.gcr.IsHost(host):
 		return c.gcr, host, path
 	case c.quay.IsHost(host):

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -82,6 +82,19 @@ func TestFromImageURL(t *testing.T) {
 			expPath:   "version-checker",
 		},
 
+		"123.dkr.foo.amazon.com should be ecr": {
+			url:       "123.dkr.ecr.foo.amazonaws.com/version-checker",
+			expClient: handler.ecr,
+			expHost:   "123.dkr.ecr.foo.amazonaws.com",
+			expPath:   "version-checker",
+		},
+		"hello.dkr.eu-west-1.amazon.com.cn should be ecr": {
+			url:       "hello.dkr.ecr.eu-west-1.amazonaws.com.cn/jetstack/joshvanl/version-checker",
+			expClient: handler.ecr,
+			expHost:   "hello.dkr.ecr.eu-west-1.amazonaws.com.cn",
+			expPath:   "jetstack/joshvanl/version-checker",
+		},
+
 		"gcr.io should be gcr": {
 			url:       "gcr.io/jetstack-cre/version-checker",
 			expClient: handler.gcr,

--- a/pkg/client/ecr/ecr.go
+++ b/pkg/client/ecr/ecr.go
@@ -85,12 +85,11 @@ func (c *Client) getClient(region string) (*ecr.ECR, error) {
 	c.cacheMu.Lock()
 	defer c.cacheMu.Unlock()
 
-	var err error
-
 	client, ok := c.cachedRegionClients[region]
 	if !ok || client == nil || client.Config.Credentials.IsExpired() {
-
 		// If the client is not yet created, or the token has expired, create new.
+
+		var err error
 		client, err = c.createRegionClient(region)
 		if err != nil {
 			return nil, err

--- a/pkg/client/ecr/ecr.go
+++ b/pkg/client/ecr/ecr.go
@@ -1,0 +1,125 @@
+package ecr
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecr"
+
+	"github.com/jetstack/version-checker/pkg/api"
+)
+
+type Client struct {
+	cacheMu             sync.Mutex
+	cachedRegionClients map[string]*ecr.ECR
+
+	Options
+}
+
+type Options struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+}
+
+func New(opts Options) *Client {
+	return &Client{
+		Options:             opts,
+		cachedRegionClients: make(map[string]*ecr.ECR),
+	}
+}
+
+func (c *Client) Tags(ctx context.Context, host, repo, image string) ([]api.ImageTag, error) {
+	matches := ecrPattern.FindStringSubmatch(host)
+	if len(matches) < 3 {
+		return nil, fmt.Errorf("aws client not suitable for image host: %s", host)
+	}
+
+	id := matches[1]
+	region := matches[3]
+
+	client, err := c.getClient(region)
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct ecr client for image host %s: %s",
+			host, err)
+	}
+
+	images, err := client.DescribeImagesWithContext(ctx, &ecr.DescribeImagesInput{
+		RepositoryName: joinRepoImage(repo, image),
+		RegistryId:     aws.String(id),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe images: %s", err)
+	}
+
+	var tags []api.ImageTag
+	for _, img := range images.ImageDetails {
+
+		// Continue early if no tags available
+		if len(img.ImageTags) == 0 {
+			tags = append(tags, api.ImageTag{
+				SHA:       *img.ImageDigest,
+				Timestamp: *img.ImagePushedAt,
+			})
+
+			continue
+		}
+
+		for _, tag := range img.ImageTags {
+			tags = append(tags, api.ImageTag{
+				SHA:       *img.ImageDigest,
+				Timestamp: *img.ImagePushedAt,
+				Tag:       *tag,
+			})
+		}
+	}
+
+	return tags, nil
+}
+
+func (c *Client) getClient(region string) (*ecr.ECR, error) {
+	c.cacheMu.Lock()
+	defer c.cacheMu.Unlock()
+
+	var err error
+
+	client, ok := c.cachedRegionClients[region]
+	if !ok || client == nil || client.Config.Credentials.IsExpired() {
+
+		// If the client is not yet created, or the token has expired, create new.
+		client, err = c.createRegionClient(region)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	c.cachedRegionClients[region] = client
+	return client, nil
+}
+
+func (c *Client) createRegionClient(region string) (*ecr.ECR, error) {
+	sess, err := session.NewSession(&aws.Config{
+		Credentials: credentials.NewStaticCredentials(c.AccessKeyID, c.SecretAccessKey, c.SessionToken),
+		Region:      &region,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct aws credentials: %s", err)
+	}
+
+	return ecr.New(sess, sess.Config), nil
+}
+
+func joinRepoImage(repo, image string) *string {
+	if len(repo) == 0 {
+		return &image
+	}
+	if len(image) == 0 {
+		return &repo
+	}
+
+	return aws.String(repo + "/" + image)
+}

--- a/pkg/client/ecr/ecr_test.go
+++ b/pkg/client/ecr/ecr_test.go
@@ -1,0 +1,47 @@
+package ecr
+
+import (
+	"testing"
+)
+
+func TestJoinRepoImage(t *testing.T) {
+	tests := map[string]struct {
+		repo, image string
+		expPath     string
+	}{
+		"single image should return as image": {
+			repo:    "",
+			image:   "kube-scheduler",
+			expPath: "kube-scheduler",
+		},
+		"single repo should return as repo": {
+			repo:    "kube-scheduler",
+			image:   "",
+			expPath: "kube-scheduler",
+		},
+		"two segments to path should return both": {
+			repo:    "jetstack-cre",
+			image:   "version-checker",
+			expPath: "jetstack-cre/version-checker",
+		},
+		"multiple segments to repo should return all in repo and image": {
+			repo:    "k8s-artifacts-prod/ingress-nginx",
+			image:   "nginx",
+			expPath: "k8s-artifacts-prod/ingress-nginx/nginx",
+		},
+		"multiple segments to image should return all in repo and image": {
+			repo:    "k8s-artifacts-prod",
+			image:   "ingress-nginx/nginx",
+			expPath: "k8s-artifacts-prod/ingress-nginx/nginx",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if path := joinRepoImage(test.repo, test.image); *path != test.expPath {
+				t.Errorf("%s,%s: unexpected path, exp=%s got=%s",
+					test.repo, test.repo, test.expPath, *path)
+			}
+		})
+	}
+}

--- a/pkg/client/ecr/path.go
+++ b/pkg/client/ecr/path.go
@@ -1,0 +1,24 @@
+package ecr
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	ecrPattern = regexp.MustCompile(`(^[a-zA-Z0-9][a-zA-Z0-9-_]*)\.dkr\.ecr(\-fips)?\.([a-zA-Z0-9][a-zA-Z0-9-_]*)\.amazonaws\.com(\.cn)?$`)
+)
+
+func (c *Client) IsHost(host string) bool {
+	return ecrPattern.MatchString(host)
+}
+
+func (c *Client) RepoImageFromPath(path string) (string, string) {
+	lastIndex := strings.LastIndex(path, "/")
+
+	if lastIndex == -1 {
+		return "", path
+	}
+
+	return path[:lastIndex], path[lastIndex+1:]
+}

--- a/pkg/client/ecr/path_test.go
+++ b/pkg/client/ecr/path_test.go
@@ -1,0 +1,103 @@
+package ecr
+
+import "testing"
+
+func TestIsHost(t *testing.T) {
+	tests := map[string]struct {
+		host  string
+		expIs bool
+	}{
+		"an empty host should be false": {
+			host:  "",
+			expIs: false,
+		},
+		"random string should be false": {
+			host:  "foobar",
+			expIs: false,
+		},
+		"random string with dots should be false": {
+			host:  "foobar.foo",
+			expIs: false,
+		},
+		"just amazonawsaws.com should be false": {
+			host:  "amazonaws.com",
+			expIs: false,
+		},
+		"ecr.foo.amazonaws.com with random sub domains should be false": {
+			host:  "bar.ecr.foo.amazonaws.com",
+			expIs: false,
+		},
+		"dkr.ecr.foo.amazonaws.com with random sub domains should be false": {
+			host:  "dkr.ecr.foo.amazonaws.com",
+			expIs: false,
+		},
+		"hello123.dkr.ecr.foo.amazonaws.com true": {
+			host:  "hello123.dkr.ecr.foo.amazonaws.com",
+			expIs: true,
+		},
+		"123hello.dkr.ecr.foo.amazonaws.com true": {
+			host:  "123hello.dkr.ecr.foo.amazonaws.com",
+			expIs: true,
+		},
+		"hello123.dkr.ecr.foo.amazonaws.com.cn true": {
+			host:  "hello123.dkr.ecr.foo.amazonaws.com.cn",
+			expIs: true,
+		},
+		"123hello.dkr.ecr.foo.amazonaws.com.cn true": {
+			host:  "123hello.dkr.ecr.foo.amazonaws.com.cn",
+			expIs: true,
+		},
+		"123hello.hello.dkr.ecr.foo.amazonaws.com false": {
+			host:  "123hello.hello.dkr.ecr.foo.amazonaws.com",
+			expIs: false,
+		},
+		"123hello.dkr.ecr.foo.amazonaws.comfoo false": {
+			host:  "123hello.dkr.ecr.foo.amazonaws.comfoo",
+			expIs: false,
+		},
+	}
+
+	handler := new(Client)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if isHost := handler.IsHost(test.host); isHost != test.expIs {
+				t.Errorf("%s: unexpected IsHost, exp=%t got=%t",
+					test.host, test.expIs, isHost)
+			}
+		})
+	}
+}
+
+func TestRepoImage(t *testing.T) {
+	tests := map[string]struct {
+		path              string
+		expRepo, expImage string
+	}{
+		"single image should return as image": {
+			path:     "kube-scheduler",
+			expRepo:  "",
+			expImage: "kube-scheduler",
+		},
+		"two segments to path should return both": {
+			path:     "jetstack-cre/version-checker",
+			expRepo:  "jetstack-cre",
+			expImage: "version-checker",
+		},
+		"multiple segments to path should return all in repo, last segment image": {
+			path:     "k8s-artifacts-prod/ingress-nginx/nginx",
+			expRepo:  "k8s-artifacts-prod/ingress-nginx",
+			expImage: "nginx",
+		},
+	}
+
+	handler := new(Client)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if repo, image := handler.RepoImageFromPath(test.path); !(repo == test.expRepo &&
+				image == test.expImage) {
+				t.Errorf("%s: unexpected repo/image, exp=%s,%s got=%s,%s",
+					test.path, test.expRepo, test.expImage, repo, image)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for checking versions of images in a private ECR repository.

version-checker expects the following environment variables (or flags) for authenticating to ECR.

```
VERSION_CHECKER_ECR_ACCESS_KEY_ID
VERSION_CHECKER_ECR_SECRET_ACCESS_KEY
VERSION_CHECKER_ECR_SESSION_TOKEN
```

fixes #21 