### PR TITLE
Add URL override

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ enrich version checking on image tags:
     `use-metadata.version-checker.io` is not required when this is set. All
     other options are ignored when this is set.
 
+- `override-url.version-checker.io/my-container: docker.io/bitnami/etcd`: is
+    used to change the URL for where to lookup where the latest image version
+    is. In this example, the current version of `my-container` will be compared
+    against the image versions in the `docker.io/bitnami/etcd` registry.
+
 ## Metrics
 
 By default, version-checker will expose the version information as Prometheus

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -6,9 +6,22 @@ import (
 )
 
 const (
+	// EnableAnnotationKey is used for enabling or disabling version-checker for
+	// a given container.
 	EnableAnnotationKey = "enable.version-checker.io"
 
-	UseSHAAnnotationKey     = "use-sha.version-checker.io"
+	// OverrideURLAnnotationKey is used to override the lookup URL. Useful when
+	// mirroring images.
+	OverrideURLAnnotationKey = "override-url.version-checker.io"
+
+	// UseSHAAnnotationKey is used to comparing the SHA digests of images. This
+	// is silently set to true if the container image using using the SHA digest
+	// as its tag.
+	UseSHAAnnotationKey = "use-sha.version-checker.io"
+
+	// MatchRegexAnnotationKey will enforce that tags that are looked up must
+	// match this regex. UseMetaDataAnnotationKey is not required when this is
+	// set. All other options are ignored when this is set.
 	MatchRegexAnnotationKey = "match-regex.version-checker.io"
 
 	// UseMetaDataAnnotationKey is defined as a tag containing anything after the
@@ -16,16 +29,21 @@ const (
 	// e.g. v1.0.1-gke.3 v1.0.1-alpha.0, v1.2.3.4
 	UseMetaDataAnnotationKey = "use-metadata.version-checker.io"
 
+	// PinMajorAnnotationKey will pin the major version to check.
 	PinMajorAnnotationKey = "pin-major.version-checker.io"
-	PinMinorAnnotationKey = "pin-minor.version-checker.io"
-	PinPatchAnnotationKey = "pin-patch.version-checker.io"
 
-	// TODO: set OS + arch options
+	// PinMinorAnnotationKey will pin the minor version to check.
+	PinMinorAnnotationKey = "pin-minor.version-checker.io"
+
+	// PinPatchAnnotationKey will pin the patch version to check.
+	PinPatchAnnotationKey = "pin-patch.version-checker.io"
 )
 
 // Options is used to describe what restrictions should be used for determining
 // the latest image.
 type Options struct {
+	OverrideURL *string `json:"override-url,omitempty"`
+
 	// UseSHA cannot be used with any other options
 	UseSHA bool `json:"use-sha,omitempty"`
 

--- a/pkg/controller/sync.go
+++ b/pkg/controller/sync.go
@@ -242,6 +242,10 @@ func (c *Controller) buildOptions(containerName string, annotations map[string]s
 		}
 	}
 
+	if overrideURL, ok := annotations[api.OverrideURLAnnotationKey+"/"+containerName]; ok {
+		opts.OverrideURL = &overrideURL
+	}
+
 	if opts.UseSHA && setNonSha {
 		errs = append(errs, fmt.Sprintf("cannot define %q with any semver otions",
 			api.UseSHAAnnotationKey+"/"+containerName))

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -44,6 +44,10 @@ func (v *Version) Run(refreshRate time.Duration) {
 // LatestTagFromImage will return the latest tag given an imageURL, according
 // to the given options.
 func (v *Version) LatestTagFromImage(ctx context.Context, imageURL string, opts *api.Options) (*api.ImageTag, error) {
+	if override := opts.OverrideURL; override != nil && len(*override) > 0 {
+		v.log.Debugf("overriding image lookup %s -> %s", imageURL, *override)
+		imageURL = *override
+	}
 	tagsI, err := v.imageCache.Get(ctx, imageURL, imageURL, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR introduces the `override-url.version-checker.io` annotation to override the image URL lookup, of the given container.

/assign
fixes #24 