### PR TITLE
Add link to preflight in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ alert cluster operators.
 
 > This tool is currently experimental.
 
+If you're interested in this tool, version checking is a built-in feature
+in our [Preflight](https://preflight.jetstack.io/) product. You may want to 
+check it out if you would like multi-cluster component version checking.
+
 ## Registries
 
 version-checker supports the following registries:


### PR DESCRIPTION
This is a preflight feature we're keen to make users of the tool aware of.