### PR TITLE
Add yaml deploy kustomization file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ These registries support authentication.
 version-checker can be installed as either static manifests;
 
 ```sh
-$ cd ./deploy/yaml && kubectl apply -f .
+$ kubectl apply -k ./deploy/yaml
 ```
 
 Or through helm;

--- a/deploy/yaml/kustomization.yaml
+++ b/deploy/yaml/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deploy.yaml


### PR DESCRIPTION
This adds a `kustomization.yaml` file to the static deploy, allowing the use of kustomize to apply manifest changes without the need to vendor the entire manifest, such as:

```
# some/path/kustomization.yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
namespace: new  # this will patch the namespace of the resources
resources:
- github.com/jetstack/version-checker/deploy/yaml?ref=v0.3.0
```

Then use it with `kustomize build some/path/` or `kubectl --kustomize ...`, e.g., `kubectl diff -k 'github.com/rochacon/version-checker/deploy/yaml?ref=kustomization'`