### PR TITLE
Fixes image URL parsing for the fallback client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -127,5 +127,5 @@ func (c *Client) fromImageURL(imageURL string) (ImageClient, string, string) {
 	}
 
 	// fall back to docker with no path split
-	return c.fallbackClient, "", imageURL
+	return c.fallbackClient, host, path
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -139,6 +139,12 @@ func TestFromImageURL(t *testing.T) {
 			expHost:   "docker.repositories.yourdomain.com",
 			expPath:   "ingress-nginx/nginx",
 		},
+		"selfhosted with different domain should be fallback": {
+			url:       "registry.opensource.zalan.do/teapot/external-dns",
+			expClient: new(selfhosted.Client),
+			expHost:   "registry.opensource.zalan.do",
+			expPath:   "teapot/external-dns",
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>

fixes #53 

Passes the parsed host and path to the fallback client.