### PR TITLE
Add generic client for registries

### DIFF
--- a/pkg/client/docker/docker.go
+++ b/pkg/client/docker/docker.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jetstack/version-checker/pkg/api"
+	"github.com/jetstack/version-checker/pkg/client/generic"
 )
 
 const (
@@ -25,6 +26,7 @@ type Options struct {
 }
 
 type Client struct {
+	genericClient *generic.Client
 	*http.Client
 	Options
 }

--- a/pkg/client/generic/errors/errors.go
+++ b/pkg/client/generic/errors/errors.go
@@ -1,0 +1,24 @@
+package errors
+
+import "fmt"
+
+type HTTPError struct {
+	Body       []byte
+	StatusCode int
+}
+
+func NewHTTPError(statusCode int, body []byte) *HTTPError {
+	return &HTTPError{
+		StatusCode: statusCode,
+		Body:       body,
+	}
+}
+
+func (h *HTTPError) Error() string {
+	return fmt.Sprintf("%s", h.Body)
+}
+
+func IsHTTPError(err error) (*HTTPError, bool) {
+	httpError, ok := err.(*HTTPError)
+	return httpError, ok
+}

--- a/pkg/client/generic/generic.go
+++ b/pkg/client/generic/generic.go
@@ -1,0 +1,286 @@
+package generic
+
+/*
+	Generic client for container registries
+*/
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/jetstack/version-checker/pkg/api"
+	genericerrors "github.com/jetstack/version-checker/pkg/client/generic/errors"
+	"github.com/jetstack/version-checker/pkg/client/util"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// {host}/v2/{repo/image}/tags/list?n=500
+	tagsPath = "%s/v2/%s/tags/list?n=500"
+	// /v2/{repo/image}/manifests/{tag}
+	manifestPath = "%s/v2/%s/manifests/%s"
+	// Token endpoint
+	tokenPath = "/v2/token"
+
+	// HTTP headers to request API version
+	dockerAPIv1Header = "application/vnd.docker.distribution.manifest.v1+json"
+	dockerAPIv2Header = "application/vnd.docker.distribution.manifest.v2+json"
+)
+
+type Options struct {
+	Host     string
+	Username string
+	Password string
+	Bearer   string
+}
+
+type Client struct {
+	*http.Client
+	*Options
+
+	log *logrus.Entry
+
+	hostRegex  *regexp.Regexp
+	httpScheme string
+}
+
+type AuthResponse struct {
+	Token string `json:"token"`
+}
+
+type TagResponse struct {
+	Tags []string `json:"tags"`
+}
+
+type ManifestResponse struct {
+	Digest       string
+	Architecture string    `json:"architecture"`
+	History      []History `json:"history"`
+}
+
+type History struct {
+	V1Compatibility string `json:"v1Compatibility"`
+}
+
+type V1Compatibility struct {
+	Created time.Time `json:"created,omitempty"`
+}
+
+func New(ctx context.Context, c *http.Client, log *logrus.Entry, opts *Options) (*Client, error) {
+	if c == nil {
+		// default http client
+		c = &http.Client{
+			Timeout: time.Second * 10,
+		}
+	}
+
+	client := &Client{
+		Client:  c,
+		Options: opts,
+		log:     log.WithField("client", opts.Host),
+	}
+
+	// Set up client with host matching if set
+	if opts.Host != "" {
+		hostRegex, scheme, err := parseURL(opts.Host)
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing url: %s", err)
+		}
+		client.hostRegex = hostRegex
+		client.httpScheme = scheme
+
+		// Setup Auth if username and password used.
+		if len(opts.Username) > 0 || len(opts.Password) > 0 {
+			if len(opts.Bearer) > 0 {
+				return nil, errors.New("cannot specify Bearer token as well as username/password")
+			}
+
+			token, err := client.setupBasicAuth(ctx, fmt.Sprintf("%s%s", opts.Host, tokenPath))
+			if httpErr, ok := genericerrors.IsHTTPError(err); ok {
+				return nil, fmt.Errorf("failed to setup token auth (%d): %s",
+					httpErr.StatusCode, httpErr.Body)
+			}
+
+			if err != nil {
+				return nil, fmt.Errorf("failed to setup token auth: %s", err)
+			}
+			client.Bearer = token
+		}
+	}
+
+	// Default to https if no scheme set
+	if client.httpScheme == "" {
+		client.httpScheme = "https"
+	}
+
+	return client, nil
+}
+
+// Name returns the name of the host URL for the selfhosted client
+func (c *Client) Name() string {
+	if len(c.Host) == 0 {
+		return "dockerapi"
+	}
+
+	return c.Host
+}
+
+// Tags will fetch the image tags from a given image URL. It must first query
+// the tags that are available, then query the 2.1 and 2.2 API endpoints to
+// gather the image digest and created time.
+func (c *Client) Tags(ctx context.Context, host, repo, image string) ([]api.ImageTag, error) {
+	path := util.JoinRepoImage(repo, image)
+	tagURL := fmt.Sprintf(tagsPath, host, path)
+
+	var tagResponse TagResponse
+	tagRequest, err := c.buildRequest(ctx, tagURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := c.doRequest(tagRequest, &tagResponse); err != nil {
+		return nil, err
+	}
+
+	var tags []api.ImageTag
+	for _, tag := range tagResponse.Tags {
+		manifestURL := fmt.Sprintf(manifestPath, host, path, tag)
+
+		var manifestResponse ManifestResponse
+		manifestV1Request, err := c.buildRequest(ctx, manifestURL, map[string]string{"Accept": dockerAPIv1Header})
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = c.doRequest(manifestV1Request, &manifestResponse)
+		if httpErr, ok := genericerrors.IsHTTPError(err); ok {
+			c.log.Errorf("%s: failed to get manifest response for tag, skipping (%d): %s",
+				manifestURL, httpErr.StatusCode, httpErr.Body)
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		var timestamp time.Time
+		for _, v1History := range manifestResponse.History {
+			data := V1Compatibility{}
+			if err := json.Unmarshal([]byte(v1History.V1Compatibility), &data); err != nil {
+				return nil, err
+			}
+
+			if !data.Created.IsZero() {
+				timestamp = data.Created
+				// Each layer has its own created timestamp. We just want a general reference.
+				// Take the first and step out the loop
+				break
+			}
+		}
+
+		manifestV2Request, err := c.buildRequest(ctx, manifestURL, map[string]string{"Accept": dockerAPIv2Header})
+		if err != nil {
+			return nil, err
+		}
+		header, err := c.doRequest(manifestV2Request, new(ManifestResponse))
+		if httpErr, ok := genericerrors.IsHTTPError(err); ok {
+			c.log.Errorf("%s: failed to get manifest sha response for tag, skipping (%d): %s",
+				manifestURL, httpErr.StatusCode, httpErr.Body)
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		tags = append(tags, api.ImageTag{
+			Tag:          tag,
+			SHA:          header.Get("Docker-Content-Digest"),
+			Timestamp:    timestamp,
+			Architecture: manifestResponse.Architecture,
+		})
+	}
+
+	return tags, nil
+}
+
+func (c *Client) buildRequest(ctx context.Context, url string, headers map[string]string) (*http.Request, error) {
+	// assuming the caller is passing a complete and valid url
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	for header, value := range headers {
+		// key in the headers is case insensitive
+		req.Header.Set(header, value)
+	}
+	if len(req.Header.Get("Authorization")) == 0 && len(c.Bearer) > 0 {
+		req.Header.Add("Authorization", "Bearer "+c.Bearer)
+	}
+	req = req.WithContext(ctx)
+	return req, nil
+}
+
+func (c *Client) doRequest(request *http.Request, obj interface{}) (http.Header, error) {
+	resp, err := c.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get docker image: %s", err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, genericerrors.NewHTTPError(resp.StatusCode, body)
+	}
+
+	if err := json.Unmarshal(body, obj); err != nil {
+		return nil, fmt.Errorf("unexpected %s response: %s", request.URL, body)
+	}
+
+	return resp.Header, nil
+}
+
+func (c *Client) setupBasicAuth(ctx context.Context, url string) (string, error) {
+	upReader := strings.NewReader(
+		fmt.Sprintf(`{"username": "%s", "password": "%s"}`,
+			c.Username, c.Password,
+		),
+	)
+
+	req, err := http.NewRequest(http.MethodPost, url, upReader)
+	if err != nil {
+		return "", fmt.Errorf("failed to create basic auth request: %s", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(ctx)
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to send basic auth request %q: %s",
+			req.URL, err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", genericerrors.NewHTTPError(resp.StatusCode, body)
+	}
+
+	response := new(AuthResponse)
+	if err := json.Unmarshal(body, response); err != nil {
+		return "", err
+	}
+
+	return response.Token, nil
+}

--- a/pkg/client/generic/path.go
+++ b/pkg/client/generic/path.go
@@ -1,0 +1,48 @@
+package generic
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+const (
+	// Regex template to be used to check "isHost"
+	hostRegTemplate = `^.*%s$`
+)
+
+func (c *Client) IsHost(host string) bool {
+	return c.hostRegex.MatchString(host)
+}
+
+func (c *Client) RepoImageFromPath(path string) (string, string) {
+	split := strings.Split(path, "/")
+
+	lenSplit := len(split)
+	if lenSplit == 1 {
+		return "", split[0]
+	}
+
+	if lenSplit > 1 {
+		return split[lenSplit-2], split[lenSplit-1]
+	}
+
+	return path, ""
+}
+
+func parseURL(rawurl string) (*regexp.Regexp, string, error) {
+	parsedURL, err := url.Parse(rawurl)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed parsing host %q: %s", rawurl, err)
+	}
+
+	hostRegTemplate := fmt.Sprintf(hostRegTemplate, parsedURL.Host)
+	hostRegex, err := regexp.Compile(hostRegTemplate)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to parse regex: %s for host %q: %s",
+			hostRegTemplate, parsedURL.Host, err)
+	}
+
+	return hostRegex, parsedURL.Scheme, nil
+}

--- a/pkg/client/generic/path_test.go
+++ b/pkg/client/generic/path_test.go
@@ -1,0 +1,121 @@
+package generic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestIsHost(t *testing.T) {
+	tests := map[string]struct {
+		host  string
+		expIs bool
+	}{
+		"an empty host should be false": {
+			host:  "",
+			expIs: false,
+		},
+		"random string should be false": {
+			host:  "foobar",
+			expIs: false,
+		},
+		"random string with dots should be false": {
+			host:  "foobar.foo",
+			expIs: false,
+		},
+		"just docker.io should be false": {
+			host:  "docker.io",
+			expIs: false,
+		},
+		"just docker.com should be false": {
+			host:  "docker.com",
+			expIs: false,
+		},
+		"docker.com with random sub domains should be false": {
+			host:  "foo.bar.docker.com",
+			expIs: false,
+		},
+		"docker.io with random sub domains should be false": {
+			host:  "foo.bar.docker.io",
+			expIs: false,
+		},
+		"docker.comfoo should be false": {
+			host:  "docker.iofoo",
+			expIs: false,
+		},
+		"docker.iofoo should be false": {
+			host:  "ocker.iofoo",
+			expIs: false,
+		},
+		"docker.repositories.yourdomain.ext should be true": {
+			host:  "docker.repositories.yourdomain.ext",
+			expIs: true,
+		},
+		"docker.repositories.yourdomain.ext with a wrong URL should be false": {
+			host:  "foo.repositories.yourdomain.ext",
+			expIs: false,
+		},
+		"docker.repositories.yourdomain.ext with a URL and PATH should be false": {
+			host:  "docker.repositories.yourdomain.ext/hello-world",
+			expIs: false,
+		},
+		"docker.repositories.yourdomain.ext with sub domain should be true": {
+			host:  "foo.docker.repositories.yourdomain.ext",
+			expIs: true,
+		},
+	}
+
+	options := &Options{
+		Host: "https://docker.repositories.yourdomain.ext",
+	}
+
+	handler, err := New(context.TODO(), logrus.NewEntry(logrus.New()), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if isHost := handler.IsHost(test.host); isHost != test.expIs {
+				t.Errorf("%s: unexpected IsHost, exp=%t got=%t",
+					test.host, test.expIs, isHost)
+			}
+		})
+	}
+}
+
+func TestRepoImage(t *testing.T) {
+	tests := map[string]struct {
+		path              string
+		expRepo, expImage string
+	}{
+		"single image should return error": {
+			path:     "nginx",
+			expRepo:  "",
+			expImage: "",
+		},
+		"two segments to path should return both": {
+			path:     "joshvanl/version-checker",
+			expRepo:  "joshvanl",
+			expImage: "version-checker",
+		},
+		"multiple segments to path should return last two": {
+			path:     "registry/joshvanl/version-checker",
+			expRepo:  "joshvanl",
+			expImage: "version-checker",
+		},
+	}
+
+	handler := new(Client)
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			repo, image := handler.RepoImageFromPath(test.path)
+			if repo != test.expRepo && image != test.expImage {
+				t.Errorf("%s: unexpected repo/image, exp=%s/%s got=%s/%s",
+					test.path, test.expRepo, test.expImage, repo, image)
+			}
+
+		})
+	}
+}

--- a/pkg/client/selfhosted/path.go
+++ b/pkg/client/selfhosted/path.go
@@ -1,48 +1,14 @@
 package selfhosted
 
-import (
-	"fmt"
-	"net/url"
-	"regexp"
-	"strings"
-)
-
 const (
 	// Regex template to be used to check "isHost"
 	hostRegTemplate = `^.*%s$`
 )
 
 func (c *Client) IsHost(host string) bool {
-	return c.hostRegex.MatchString(host)
+	return c.IsHost(host)
 }
 
 func (c *Client) RepoImageFromPath(path string) (string, string) {
-	split := strings.Split(path, "/")
-
-	lenSplit := len(split)
-	if lenSplit == 1 {
-		return "", split[0]
-	}
-
-	if lenSplit > 1 {
-		return split[lenSplit-2], split[lenSplit-1]
-	}
-
-	return path, ""
-}
-
-func parseURL(rawurl string) (*regexp.Regexp, string, error) {
-	parsedURL, err := url.Parse(rawurl)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed parsing host %q: %s", rawurl, err)
-	}
-
-	hostRegTemplate := fmt.Sprintf(hostRegTemplate, parsedURL.Host)
-	hostRegex, err := regexp.Compile(hostRegTemplate)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to parse regex: %s for host %q: %s",
-			hostRegTemplate, parsedURL.Host, err)
-	}
-
-	return hostRegex, parsedURL.Scheme, nil
+	return c.RepoImageFromPath(path)
 }

--- a/pkg/client/selfhosted/selfhosted.go
+++ b/pkg/client/selfhosted/selfhosted.go
@@ -2,33 +2,11 @@ package selfhosted
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"regexp"
-	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/jetstack/version-checker/pkg/api"
-	selfhostederrors "github.com/jetstack/version-checker/pkg/client/selfhosted/errors"
-	"github.com/jetstack/version-checker/pkg/client/util"
-)
-
-const (
-	// {host}/v2/{repo/image}/tags/list?n=500
-	tagsPath = "%s/v2/%s/tags/list?n=500"
-	// /v2/{repo/image}/manifests/{tag}
-	manifestPath = "%s/v2/%s/manifests/%s"
-	// Token endpoint
-	tokenPath = "/v2/token"
-
-	// HTTP headers to request API version
-	dockerAPIv1Header = "application/vnd.docker.distribution.manifest.v1+json"
-	dockerAPIv2Header = "application/vnd.docker.distribution.manifest.v2+json"
+	"github.com/jetstack/version-checker/pkg/client/generic"
 )
 
 type Options struct {
@@ -39,77 +17,27 @@ type Options struct {
 }
 
 type Client struct {
-	*http.Client
-	*Options
-
-	log *logrus.Entry
-
-	hostRegex  *regexp.Regexp
-	httpScheme string
-}
-
-type AuthResponse struct {
-	Token string `json:"token"`
-}
-
-type TagResponse struct {
-	Tags []string `json:"tags"`
-}
-
-type ManifestResponse struct {
-	Digest       string
-	Architecture string    `json:"architecture"`
-	History      []History `json:"history"`
-}
-
-type History struct {
-	V1Compatibility string `json:"v1Compatibility"`
-}
-
-type V1Compatibility struct {
-	Created time.Time `json:"created,omitempty"`
+	genericClient *generic.Client
+	log           *logrus.Entry
 }
 
 func New(ctx context.Context, log *logrus.Entry, opts *Options) (*Client, error) {
+	log = log.WithField("client", opts.Host)
+	genericOptions := &generic.Options{
+		Host:     opts.Host,
+		Username: opts.Username,
+		Password: opts.Password,
+		Bearer:   opts.Bearer,
+	}
+
+	genericClient, err := generic.New(ctx, nil, log, genericOptions)
+	if err != nil {
+		return nil, err
+	}
+
 	client := &Client{
-		Client: &http.Client{
-			Timeout: time.Second * 10,
-		},
-		Options: opts,
-		log:     log.WithField("client", opts.Host),
-	}
-
-	// Set up client with host matching if set
-	if opts.Host != "" {
-		hostRegex, scheme, err := parseURL(opts.Host)
-		if err != nil {
-			return nil, fmt.Errorf("failed parsing url: %s", err)
-		}
-		client.hostRegex = hostRegex
-		client.httpScheme = scheme
-
-		// Setup Auth if username and password used.
-		if len(opts.Username) > 0 || len(opts.Password) > 0 {
-			if len(opts.Bearer) > 0 {
-				return nil, errors.New("cannot specify Bearer token as well as username/password")
-			}
-
-			token, err := client.setupBasicAuth(ctx, opts.Host)
-			if httpErr, ok := selfhostederrors.IsHTTPError(err); ok {
-				return nil, fmt.Errorf("failed to setup token auth (%d): %s",
-					httpErr.StatusCode, httpErr.Body)
-			}
-
-			if err != nil {
-				return nil, fmt.Errorf("failed to setup token auth: %s", err)
-			}
-			client.Bearer = token
-		}
-	}
-
-	// Default to https if no scheme set
-	if client.httpScheme == "" {
-		client.httpScheme = "https"
+		genericClient: genericClient,
+		log:           log,
 	}
 
 	return client, nil
@@ -117,149 +45,12 @@ func New(ctx context.Context, log *logrus.Entry, opts *Options) (*Client, error)
 
 // Name returns the name of the host URL for the selfhosted client
 func (c *Client) Name() string {
-	if len(c.Host) == 0 {
-		return "dockerapi"
-	}
-
-	return c.Host
+	return c.Name()
 }
 
 // Tags will fetch the image tags from a given image URL. It must first query
 // the tags that are available, then query the 2.1 and 2.2 API endpoints to
 // gather the image digest and created time.
 func (c *Client) Tags(ctx context.Context, host, repo, image string) ([]api.ImageTag, error) {
-	path := util.JoinRepoImage(repo, image)
-	tagURL := fmt.Sprintf(tagsPath, host, path)
-
-	var tagResponse TagResponse
-	if _, err := c.doRequest(ctx, tagURL, "", &tagResponse); err != nil {
-		return nil, err
-	}
-
-	var tags []api.ImageTag
-	for _, tag := range tagResponse.Tags {
-		manifestURL := fmt.Sprintf(manifestPath, host, path, tag)
-
-		var manifestResponse ManifestResponse
-		_, err := c.doRequest(ctx, manifestURL, dockerAPIv1Header, &manifestResponse)
-
-		if httpErr, ok := selfhostederrors.IsHTTPError(err); ok {
-			c.log.Errorf("%s: failed to get manifest response for tag, skipping (%d): %s",
-				manifestURL, httpErr.StatusCode, httpErr.Body)
-			continue
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		var timestamp time.Time
-		for _, v1History := range manifestResponse.History {
-			data := V1Compatibility{}
-			if err := json.Unmarshal([]byte(v1History.V1Compatibility), &data); err != nil {
-				return nil, err
-			}
-
-			if !data.Created.IsZero() {
-				timestamp = data.Created
-				// Each layer has its own created timestamp. We just want a general reference.
-				// Take the first and step out the loop
-				break
-			}
-		}
-
-		header, err := c.doRequest(ctx, manifestURL, dockerAPIv2Header, new(ManifestResponse))
-		if httpErr, ok := selfhostederrors.IsHTTPError(err); ok {
-			c.log.Errorf("%s: failed to get manifest sha response for tag, skipping (%d): %s",
-				manifestURL, httpErr.StatusCode, httpErr.Body)
-			continue
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		tags = append(tags, api.ImageTag{
-			Tag:          tag,
-			SHA:          header.Get("Docker-Content-Digest"),
-			Timestamp:    timestamp,
-			Architecture: manifestResponse.Architecture,
-		})
-	}
-
-	return tags, nil
-}
-
-func (c *Client) doRequest(ctx context.Context, url, header string, obj interface{}) (http.Header, error) {
-	url = fmt.Sprintf("%s://%s", c.httpScheme, url)
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req = req.WithContext(ctx)
-	if len(c.Bearer) > 0 {
-		req.Header.Add("Authorization", "Bearer "+c.Bearer)
-	}
-	if len(header) > 0 {
-		req.Header.Set("Accept", header)
-	}
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get docker image: %s", err)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, selfhostederrors.NewHTTPError(resp.StatusCode, body)
-	}
-
-	if err := json.Unmarshal(body, obj); err != nil {
-		return nil, fmt.Errorf("unexpected %s response: %s", url, body)
-	}
-
-	return resp.Header, nil
-}
-
-func (c *Client) setupBasicAuth(ctx context.Context, url string) (string, error) {
-	upReader := strings.NewReader(
-		fmt.Sprintf(`{"username": "%s", "password": "%s"}`,
-			c.Username, c.Password,
-		),
-	)
-
-	tokenURL := url + tokenPath
-
-	req, err := http.NewRequest(http.MethodPost, tokenURL, upReader)
-	if err != nil {
-		return "", fmt.Errorf("failed to create basic auth request: %s", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req = req.WithContext(ctx)
-
-	resp, err := c.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to send basic auth request %q: %s",
-			req.URL, err)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return "", selfhostederrors.NewHTTPError(resp.StatusCode, body)
-	}
-
-	response := new(AuthResponse)
-	if err := json.Unmarshal(body, response); err != nil {
-		return "", err
-	}
-
-	return response.Token, nil
+	return c.Tags(ctx, host, repo, image)
 }

--- a/pkg/controller/checker/checker.go
+++ b/pkg/controller/checker/checker.go
@@ -152,8 +152,17 @@ func (c *Checker) isLatestSHA(ctx context.Context, imageURL, currentSHA string, 
 
 	isLatest := latestImage.SHA == currentSHA
 	latestVersion := latestImage.SHA
+	if latestImage.CompositeHash != "" {
+		isLatest = latestImage.CompositeHash == currentSHA
+		latestVersion = latestImage.CompositeHash
+	}
 	if len(latestImage.Tag) > 0 {
-		latestVersion = fmt.Sprintf("%s@%s", latestImage.Tag, latestImage.SHA)
+		if latestImage.CompositeHash != "" {
+			latestVersion = fmt.Sprintf("%s@%s", latestImage.Tag, latestImage.CompositeHash)
+		} else {
+			latestVersion = fmt.Sprintf("%s@%s", latestImage.Tag, latestImage.SHA)
+		}
+
 	}
 
 	return &Result{


### PR DESCRIPTION
This adds a generic client that uses the docker api instead of specific
client libraries. Other clients should wrap it to make use of the dockerapi.

Signed-off-by: oluwole.fadeyi <oluwole.fadeyi@jetstack.io>