### PR TITLE
Add option to define custom environment variables

### DIFF
--- a/deploy/charts/version-checker/Chart.yaml
+++ b/deploy/charts/version-checker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "v0.2.1"
-version: 0.2.1
+version: 0.2.2
 description: A Helm chart for version-checker
 home: https://github.com/joshvanl/verison-checker
 name: version-checker

--- a/deploy/charts/version-checker/templates/deployment.yaml
+++ b/deploy/charts/version-checker/templates/deployment.yaml
@@ -159,6 +159,9 @@ spec:
               key: selfhosted.{{ $element.name }}.token
         {{- end }}
         {{- end }}
+        {{- if .Values.env }}
+        {{- toYaml .Values.env | nindent 8 }}
+        {{- end }}
 
       volumes:
         {{- if $secretEnabled }}

--- a/deploy/charts/version-checker/values.yaml
+++ b/deploy/charts/version-checker/values.yaml
@@ -39,6 +39,9 @@ gcr:
 quay:
   token:
 
+# Can be used to provide custom environment variables e.g. proxy settings
+env: {}
+
 selfhosted: {}
   #- name: REGISTRY
   #  host: http://registry:5000


### PR DESCRIPTION
We are running version-checker behind a proxy and need to define proxy environment variables for it.

```release-note
Allows to specify addition environment variables e.g. https_proxy
```