### PR TITLE
added the option to use a AWS role ARN to authenticate to ECR if on EKS

### DIFF
--- a/cmd/app/options.go
+++ b/cmd/app/options.go
@@ -27,6 +27,7 @@ const (
 	envDockerPassword = "DOCKER_PASSWORD"
 	envDockerToken    = "DOCKER_TOKEN"
 
+	envECRIamRoleArn      = "ECR_IAM_ROLE_ARN"
 	envECRAccessKeyID     = "ECR_ACCESS_KEY_ID"
 	envECRSecretAccessKey = "ECR_SECRET_ACCESS_KEY"
 	envECRSessionToken    = "ECR_SESSION_TOKEN"
@@ -154,6 +155,12 @@ func (o *Options) addAuthFlags(fs *pflag.FlagSet) {
 	///
 
 	/// ECR
+	fs.StringVar(&o.Client.ECR.IamRoleArn,
+		"ecr-iam-role-arn", "",
+		fmt.Sprintf(
+			"IAM role ARN for read access to private registries, can not be used with access-key/secret-key/session-token (%s_%s).",
+			envPrefix, envECRIamRoleArn,
+		))
 	fs.StringVar(&o.Client.ECR.AccessKeyID,
 		"ecr-access-key-id", "",
 		fmt.Sprintf(
@@ -237,6 +244,7 @@ func (o *Options) complete() {
 		{envDockerPassword, &o.Client.Docker.Password},
 		{envDockerToken, &o.Client.Docker.Token},
 
+		{envECRIamRoleArn, &o.Client.ECR.IamRoleArn},
 		{envECRAccessKeyID, &o.Client.ECR.AccessKeyID},
 		{envECRSessionToken, &o.Client.ECR.SessionToken},
 		{envECRSecretAccessKey, &o.Client.ECR.SecretAccessKey},

--- a/cmd/app/options_test.go
+++ b/cmd/app/options_test.go
@@ -33,6 +33,7 @@ func TestComplete(t *testing.T) {
 				{"VERSION_CHECKER_DOCKER_USERNAME", "docker-username"},
 				{"VERSION_CHECKER_DOCKER_PASSWORD", "docker-password"},
 				{"VERSION_CHECKER_DOCKER_TOKEN", "docker-token"},
+				{"VERSION_CHECKER_ECR_IAM_ROLE_ARN", "iam-role-arn"},
 				{"VERSION_CHECKER_ECR_ACCESS_KEY_ID", "ecr-access-token"},
 				{"VERSION_CHECKER_ECR_SECRET_ACCESS_KEY", "ecr-secret-access-token"},
 				{"VERSION_CHECKER_ECR_SESSION_TOKEN", "ecr-session-token"},
@@ -55,6 +56,7 @@ func TestComplete(t *testing.T) {
 					Token:    "docker-token",
 				},
 				ECR: ecr.Options{
+					IamRoleArn:      "iam-role-arn",
 					AccessKeyID:     "ecr-access-token",
 					SecretAccessKey: "ecr-secret-access-token",
 					SessionToken:    "ecr-session-token",
@@ -87,6 +89,7 @@ func TestComplete(t *testing.T) {
 				{"VERSION_CHECKER_DOCKER_USERNAME", "docker-username"},
 				{"VERSION_CHECKER_DOCKER_PASSWORD", "docker-password"},
 				{"VERSION_CHECKER_DOCKER_TOKEN", "docker-token"},
+				{"VERSION_CHECKER_ECR_IAM_ROLE_ARN", "iam-role-arn"},
 				{"VERSION_CHECKER_ECR_ACCESS_KEY_ID", "ecr-access-token"},
 				{"VERSION_CHECKER_ECR_SECRET_ACCESS_KEY", "ecr-secret-access-token"},
 				{"VERSION_CHECKER_ECR_SESSION_TOKEN", "ecr-session-token"},
@@ -109,6 +112,7 @@ func TestComplete(t *testing.T) {
 					Token:    "docker-token",
 				},
 				ECR: ecr.Options{
+					IamRoleArn:      "iam-role-arn",
 					AccessKeyID:     "ecr-access-token",
 					SecretAccessKey: "ecr-secret-access-token",
 					SessionToken:    "ecr-session-token",

--- a/deploy/charts/version-checker/templates/deployment.yaml
+++ b/deploy/charts/version-checker/templates/deployment.yaml
@@ -65,6 +65,10 @@ spec:
         {{- end }}
 
         # ECR
+        {{- if .Values.ecr.iamRoleArn }}
+        - name: VERSION_CHECKER_ECR_IAM_ROLE_ARN
+          value: {{ .Values.ecr.iamRoleArn }}
+        {{- end }}
         {{- if .Values.ecr.accessKeyID }}
         - name: VERSION_CHECKER_ECR_ACCESS_KEY_ID
           valueFrom:

--- a/deploy/charts/version-checker/templates/serviceaccount.yaml
+++ b/deploy/charts/version-checker/templates/serviceaccount.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  {{- if .Values.ecr.iamRoleArn }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.ecr.iamRoleArn }}
+  {{- end }}
   labels:
 {{ include "version-checker.labels" . | indent 4 }}
   name: {{ include "version-checker.name" . }}

--- a/deploy/charts/version-checker/values.yaml
+++ b/deploy/charts/version-checker/values.yaml
@@ -29,6 +29,11 @@ docker:
   token:
 
 ecr:
+  # in AWS EKS use the following
+  # https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html
+  iamRoleArn:
+
+  # else use the AWS credentials
   accessKeyID:
   secretAccessKey:
   sessionToken:

--- a/pkg/client/ecr/ecr.go
+++ b/pkg/client/ecr/ecr.go
@@ -22,6 +22,7 @@ type Client struct {
 }
 
 type Options struct {
+	IamRoleArn      string
 	AccessKeyID     string
 	SecretAccessKey string
 	SessionToken    string
@@ -107,10 +108,16 @@ func (c *Client) getClient(region string) (*ecr.ECR, error) {
 }
 
 func (c *Client) createRegionClient(region string) (*ecr.ECR, error) {
-	sess, err := session.NewSession(&aws.Config{
-		Credentials: credentials.NewStaticCredentials(c.AccessKeyID, c.SecretAccessKey, c.SessionToken),
-		Region:      &region,
-	})
+	var sess *session.Session
+	var err error
+	if c.IamRoleArn != "" {
+		sess, err = session.NewSession()
+	} else {
+		sess, err = session.NewSession(&aws.Config{
+			Credentials: credentials.NewStaticCredentials(c.AccessKeyID, c.SecretAccessKey, c.SessionToken),
+			Region:      &region,
+		})
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct aws credentials: %s", err)
 	}


### PR DESCRIPTION
```release-note
Added the option to use an AWS IAM role ARN to authenticate to ECR if on EKS as described here:
https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html
In this case you don't need to use fixed access-key/secret-key/session-token to authenticate to ECR.
```

Signed-off-by: Henryk Trappmann <henryk.trappmann@mytoys.de>