### PR TITLE
Fix docker authorization header value

### DIFF
--- a/pkg/client/docker/docker.go
+++ b/pkg/client/docker/docker.go
@@ -130,7 +130,7 @@ func (c *Client) doRequest(ctx context.Context, url string) (*TagResponse, error
 	req.URL.Scheme = "https"
 	req = req.WithContext(ctx)
 	if len(c.Token) > 0 {
-		req.Header.Add("Authorization", "Token "+c.Token)
+		req.Header.Add("Authorization", "Bearer "+c.Token)
 	}
 
 	resp, err := c.Do(req)


### PR DESCRIPTION
According to documentation, the header should be `Authorization: Bearer {TOKEN}` rather than `Authorization: Token {TOKEN}`:
https://docs.docker.com/docker-hub/api/latest/#tag/authentication/operation/PostUsersLogin

The incorrect header value seems to work ok for requests to public repositories (presumably they are being treated as anonymous requests), however private repositories will receive a `404` and in version-checker logs the corresponding error message is `no tags found for given image URL`.

Release notes:
```
Fixed a bug where an incorrect Authorization header was being passed to the docker API
```
