### PR TITLE
Sets API version of Role and RoleBinding to v1

### DIFF
--- a/deploy/charts/version-checker/Chart.yaml
+++ b/deploy/charts/version-checker/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "v0.2.1"
-version: 0.2.2
+version: 0.2.3
 description: A Helm chart for version-checker
 home: https://github.com/joshvanl/verison-checker
 name: version-checker

--- a/deploy/charts/version-checker/templates/prometheus.yaml
+++ b/deploy/charts/version-checker/templates/prometheus.yaml
@@ -5,7 +5,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.prometheus.serviceAccountName }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: prometheus
@@ -21,7 +21,7 @@ rules:
   - configmaps
   verbs: ["get"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: prometheus


### PR DESCRIPTION
Fixes #89.

Updates API version of Prometheus `Role` and `RoleBinding` in the Chart, which are [deprecated starting from 1.22](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122).