### PR TITLE
Adding k8s.io support

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -121,6 +121,18 @@ func TestFromImageURL(t *testing.T) {
 			expHost:   "us.gcr.io",
 			expPath:   "k8s-artifacts-prod/ingress-nginx/nginx",
 		},
+		"k8s.io should be gcr": {
+			url:       "k8s.io/sig-storage/csi-node-driver-registrar",
+			expClient: new(gcr.Client),
+			expHost:   "k8s.io",
+			expPath:   "sig-storage/csi-node-driver-registrar",
+		},
+		"k8s.io with subdomain should be gcr": {
+			url:       "registry.k8s.io/sig-storage/csi-node-driver-registrar",
+			expClient: new(gcr.Client),
+			expHost:   "registry.k8s.io",
+			expPath:   "sig-storage/csi-node-driver-registrar",
+		},
 
 		"ghcr.io should be ghcr": {
 			url:       "ghcr.io/jetstack/version-checker",

--- a/pkg/client/gcr/path.go
+++ b/pkg/client/gcr/path.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	reg = regexp.MustCompile(`(^(.*\.)?gcr.io$|^(.+)-docker.pkg.dev$)`)
+	reg = regexp.MustCompile(`(^(.*\.)?gcr.io$|^(.*\.)?k8s.io$|^(.+)-docker.pkg.dev$)`)
 )
 
 func (c *Client) IsHost(host string) bool {

--- a/pkg/client/gcr/path_test.go
+++ b/pkg/client/gcr/path_test.go
@@ -47,6 +47,14 @@ func TestIsHost(t *testing.T) {
 			host:  "eu-docker.pkg.dev",
 			expIs: true,
 		},
+		"k8s.io should be true": {
+			host:  "k8s.io",
+			expIs: true,
+		},
+		"registry.k8s.io should be true": {
+			host:  "registry.k8s.io",
+			expIs: true,
+		},
 	}
 
 	handler := new(Client)


### PR DESCRIPTION
As k8s.io and registry.k8s.io are GCR/GAR based repositories, lets make use of the authentication and GCR API instead of treating things as a general docker/selfhosted repository.
