### PR TITLE
Use newer alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app/
 RUN make build
 
 
-FROM alpine:3.18.2
+FROM alpine:3.18.3
 LABEL description="Kubernetes utility for exposing used image versions compared to the latest version, as metrics."
 
 RUN apk --no-cache add ca-certificates


### PR DESCRIPTION
## Before

```shell
> trivy -q image docker.io/library/alpine:3.18.2 

docker.io/library/alpine:3.18.2 (alpine 3.18.2)

Total: 9 (UNKNOWN: 0, LOW: 0, MEDIUM: 6, HIGH: 0, CRITICAL: 3)

┌───────────────┬────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│    Library    │ Vulnerability  │ Severity │ Installed Version │ Fixed Version │                            Title                            │
├───────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ busybox       │ CVE-2022-48174 │ CRITICAL │ 1.36.1-r0         │ 1.36.1-r1     │ stack overflow vulnerability in ash.c leads to arbitrary    │
│               │                │          │                   │               │ code execution                                              │
│               │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-48174                  │
├───────────────┤                │          │                   │               │                                                             │
│ busybox-binsh │                │          │                   │               │                                                             │
│               │                │          │                   │               │                                                             │
│               │                │          │                   │               │                                                             │
├───────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto3    │ CVE-2023-2975  │ MEDIUM   │ 3.1.1-r1          │ 3.1.1-r2      │ AES-SIV cipher implementation contains a bug that causes it │
│               │                │          │                   │               │ to ignore empty...                                          │
│               │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2975                   │
│               ├────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-3446  │          │                   │ 3.1.1-r3      │ Excessive time spent checking DH keys and parameters        │
│               │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│               ├────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-3817  │          │                   │ 3.1.2-r0      │ Excessive time spent checking DH q parameter value          │
│               │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
├───────────────┼────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│ libssl3       │ CVE-2023-2975  │          │                   │ 3.1.1-r2      │ AES-SIV cipher implementation contains a bug that causes it │
│               │                │          │                   │               │ to ignore empty...                                          │
│               │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2975                   │
│               ├────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-3446  │          │                   │ 3.1.1-r3      │ Excessive time spent checking DH keys and parameters        │
│               │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│               ├────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-3817  │          │                   │ 3.1.2-r0      │ Excessive time spent checking DH q parameter value          │
│               │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
├───────────────┼────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ ssl_client    │ CVE-2022-48174 │ CRITICAL │ 1.36.1-r0         │ 1.36.1-r1     │ stack overflow vulnerability in ash.c leads to arbitrary    │
│               │                │          │                   │               │ code execution                                              │
│               │                │          │                   │               │ https://avd.aquasec.com/nvd/cve-2022-48174                  │
└───────────────┴────────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
```

## After

```shell
> trivy -q image docker.io/library/alpine:3.18.3 
docker.io/library/alpine:3.18.3 (alpine 3.18.3)
===============================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```