### PR TITLE
Fix docker hub images if they have no timestamp

### DIFF
--- a/pkg/client/docker/docker.go
+++ b/pkg/client/docker/docker.go
@@ -94,9 +94,13 @@ func (c *Client) Tags(ctx context.Context, _, repo, image string) ([]api.ImageTa
 				continue
 			}
 
-			timestamp, err := time.Parse(time.RFC3339Nano, result.Timestamp)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse image timestamp: %s", err)
+			var timestamp time.Time
+			if len(result.Timestamp) > 0 {
+				timestamp, err = time.Parse(time.RFC3339Nano, result.Timestamp)
+				if err != nil {
+					fmt.Printf("RESULT: %+v\n", result)
+					return nil, fmt.Errorf("failed to parse image timestamp: %s RESULT:(%s)", err, result)
+				}
 			}
 
 			for _, image := range result.Images {

--- a/pkg/client/docker/docker.go
+++ b/pkg/client/docker/docker.go
@@ -98,8 +98,7 @@ func (c *Client) Tags(ctx context.Context, _, repo, image string) ([]api.ImageTa
 			if len(result.Timestamp) > 0 {
 				timestamp, err = time.Parse(time.RFC3339Nano, result.Timestamp)
 				if err != nil {
-					fmt.Printf("RESULT: %+v\n", result)
-					return nil, fmt.Errorf("failed to parse image timestamp: %s RESULT:(%s)", err, result)
+					return nil, fmt.Errorf("failed to parse image timestamp: %s", err)
 				}
 			}
 


### PR DESCRIPTION
Under certain conditions, the docker hub repository doesn't have the date in whcih the image was pushed, therefore resulting in version-checker not monitoring the image what so ever.

This changes the logic some what for docker hub repositories as if the timestamp is missing we default to the Unix Timestamp in the hope that SemVer checking takes precidence.

The likely hood of these images without timestamps being the latest is highly unlikely or there's a data integrity issue with the repository its self.


Resolves #123

