### PR TITLE
Fix broken pod metrics caching

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -107,7 +107,7 @@ func (m *Metrics) AddImage(namespace, pod, container, containerType, imageURL st
 		m.buildLabels(namespace, pod, container, containerType, imageURL, currentVersion, latestVersion),
 	).Set(isLatestF)
 
-	index := m.latestImageIndex(namespace, pod, container)
+	index := m.latestImageIndex(namespace, pod, container, containerType)
 	m.containerCache[index] = cacheItem{
 		image:          imageURL,
 		currentVersion: currentVersion,
@@ -119,7 +119,7 @@ func (m *Metrics) RemoveImage(namespace, pod, container, containerType string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	index := m.latestImageIndex(namespace, pod, container)
+	index := m.latestImageIndex(namespace, pod, container, containerType)
 	item, ok := m.containerCache[index]
 	if !ok {
 		return
@@ -131,8 +131,8 @@ func (m *Metrics) RemoveImage(namespace, pod, container, containerType string) {
 	delete(m.containerCache, index)
 }
 
-func (m *Metrics) latestImageIndex(namespace, pod, container string) string {
-	return strings.Join([]string{namespace, pod, container}, "")
+func (m *Metrics) latestImageIndex(namespace, pod, container, containerType string) string {
+	return strings.Join([]string{namespace, pod, container, containerType}, "")
 }
 
 func (m *Metrics) buildLabels(namespace, pod, container, containerType, imageURL, currentVersion, latestVersion string) prometheus.Labels {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,39 @@
+package metrics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sirupsen/logrus"
+)
+
+func TestCache(t *testing.T) {
+	m := New(logrus.NewEntry(logrus.New()))
+
+	for i, typ := range []string{"init", "container"} {
+		version := fmt.Sprintf("0.1.%d", i)
+		m.AddImage("namespace", "pod", "container", typ, "url", true, version, version)
+	}
+
+	for i, typ := range []string{"init", "container"} {
+		version := fmt.Sprintf("0.1.%d", i)
+		mt, _ := m.containerImageVersion.GetMetricWith(m.buildLabels("namespace", "pod", "container", typ, "url", version, version))
+		count := testutil.ToFloat64(mt)
+		if count != 1 {
+			t.Error("Should have added metric")
+		}
+	}
+
+	for _, typ := range []string{"init", "container"} {
+		m.RemoveImage("namespace", "pod", "container", typ)
+	}
+	for i, typ := range []string{"init", "container"} {
+		version := fmt.Sprintf("0.1.%d", i)
+		mt, _ := m.containerImageVersion.GetMetricWith(m.buildLabels("namespace", "pod", "container", typ, "url", version, version))
+		count := testutil.ToFloat64(mt)
+		if count != 0 {
+			t.Error("Should have removed metric")
+		}
+	}
+}


### PR DESCRIPTION
Add containerType to cache key, otherwise the cache data could be out of sync or non-existant and lead to stale entries in the prometheus gauge.