### PR TITLE
Use latest alpine (3.19.1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app/
 RUN make build
 
 
-FROM alpine:3.18.3
+FROM alpine:3.19.1
 LABEL description="Kubernetes utility for exposing used image versions compared to the latest version, as metrics."
 
 RUN apk --no-cache add ca-certificates


### PR DESCRIPTION
## Before

Update alpine version to resolve bunch of CVEs:

```
$ trivy -q image quay.io/jetstack/version-checker:v0.5.3

quay.io/jetstack/version-checker:v0.5.3 (alpine 3.18.3)

Total: 10 (UNKNOWN: 0, LOW: 0, MEDIUM: 8, HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ fixed  │ 3.1.2-r0          │ 3.1.4-r0      │ openssl: Incorrect cipher key and IV length processing    │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363                 │
│            ├───────────────┼──────────┤        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│            │ CVE-2023-5678 │ MEDIUM   │        │                   │ 3.1.4-r1      │ openssl: Generating excessively long X9.42 DH keys or     │
│            │               │          │        │                   │               │ checking excessively long X9.42...                        │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5678                 │
│            ├───────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│            │ CVE-2023-6129 │          │        │                   │ 3.1.4-r3      │ openssl: POLY1305 MAC implementation corrupts vector      │
│            │               │          │        │                   │               │ registers on PowerPC                                      │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6129                 │
│            ├───────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│            │ CVE-2023-6237 │          │        │                   │ 3.1.4-r4      │ openssl: Excessive time spent checking invalid RSA public │
│            │               │          │        │                   │               │ keys                                                      │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6237                 │
│            ├───────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│            │ CVE-2024-0727 │          │        │                   │ 3.1.4-r5      │ openssl: denial of service via null dereference           │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-0727                 │
├────────────┼───────────────┼──────────┤        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│ libssl3    │ CVE-2023-5363 │ HIGH     │        │                   │ 3.1.4-r0      │ openssl: Incorrect cipher key and IV length processing    │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363                 │
│            ├───────────────┼──────────┤        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│            │ CVE-2023-5678 │ MEDIUM   │        │                   │ 3.1.4-r1      │ openssl: Generating excessively long X9.42 DH keys or     │
│            │               │          │        │                   │               │ checking excessively long X9.42...                        │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5678                 │
│            ├───────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│            │ CVE-2023-6129 │          │        │                   │ 3.1.4-r3      │ openssl: POLY1305 MAC implementation corrupts vector      │
│            │               │          │        │                   │               │ registers on PowerPC                                      │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6129                 │
│            ├───────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│            │ CVE-2023-6237 │          │        │                   │ 3.1.4-r4      │ openssl: Excessive time spent checking invalid RSA public │
│            │               │          │        │                   │               │ keys                                                      │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6237                 │
│            ├───────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│            │ CVE-2024-0727 │          │        │                   │ 3.1.4-r5      │ openssl: denial of service via null dereference           │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-0727                 │
└────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘
```

## After

```
$ trivy -q image docker.io/library/alpine:3.19.1

docker.io/library/alpine:3.19.1 (alpine 3.19.1)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```