### PR TITLE
Helm Chart: add imagePullSecret to serviceaccount

### DIFF
--- a/deploy/charts/version-checker/templates/serviceaccount.yaml
+++ b/deploy/charts/version-checker/templates/serviceaccount.yaml
@@ -8,3 +8,7 @@ metadata:
   labels:
 {{ include "version-checker.labels" . | indent 4 }}
   name: {{ include "version-checker.name" . }}
+{{- if .Values.image.imagePullSecret }}
+imagePullSecret:
+ - name: {{ .Values.image.imagePullSecret }}
+{{- end }}

--- a/deploy/charts/version-checker/values.yaml
+++ b/deploy/charts/version-checker/values.yaml
@@ -17,6 +17,8 @@ image:
   tag: ""
   # -- Set the Image Pull Policy
   pullPolicy: IfNotPresent
+  # -- Pull secrects - name of existing secret
+  imagePullSecret:
 
 # -- Configure tolerations
 tolerations: []


### PR DESCRIPTION
In my work environment, we have have a local repository which does mirror and proxy external image repository for security reasons, it is essential to have imagePullSecrets added to the serviceaccount otherweise version-checker itself can not be pulled and started.

