### PR TITLE
Improve build speed

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -36,6 +36,8 @@ jobs:
       uses: actions/checkout@v3 # v3.5.3
     - name: Setup Go
       uses: actions/setup-go@v4
+      with:
+        cache-dependency-path: "**/*.sum"
 
     - name: Download and required packages
       run: |
@@ -60,13 +62,6 @@ jobs:
       - test
       - lint
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
-          - linux/arm/v7
     name: Build Images
     steps:
     - name: Checkout code
@@ -76,15 +71,24 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+
+    - name: Setup Go
+      uses: actions/setup-go@v4
       with:
-        platforms: ${{ matrix.platform }}
+        cache-dependency-path: "**/*.sum"
+
+    - name: Build binaries
+      run: |
+        export CGO_ENABLED=0
+        GOOS=linux GOARCH=amd64 go build -a -o dist/cmd-linux-amd64 ./cmd/.
+        GOOS=linux GOARCH=arm64 go build -a -o dist/cmd-linux-arm64 ./cmd/.
+        GOOS=linux GOARCH=arm go build -a -o dist/cmd-linux-arm ./cmd/.
 
     - name: Build Images
       uses: docker/build-push-action@v4
       with:
         context: .
-        platforms: ${{ matrix.platform }}
-        load: true
+        platforms: linux/arm64,linux/amd64,linux/arm/v7
         push: false
         tags: quay.io/jetstack/version-checker:${{github.sha}}
         cache-from: type=gha

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -93,13 +93,3 @@ jobs:
         tags: quay.io/jetstack/version-checker:${{github.sha}}
         cache-from: type=gha
         cache-to: type=gha,mode=max
-
-    - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.19.0
-      with:
-        image-ref: 'quay.io/jetstack/version-checker:${{github.sha}}'
-        format: 'table'
-        exit-code: '1'
-        ignore-unfixed: true
-        vuln-type: 'os,library'
-        severity: 'CRITICAL,HIGH'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,8 +131,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          platforms: ${{ matrix.platform }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -140,6 +138,18 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          cache-dependency-path: "**/*.sum"
+
+      - name: Build binaries
+        run: |
+          export CGO_ENABLED=0
+          GOOS=linux GOARCH=amd64 go build -a -o dist/cmd-linux-amd64 ./cmd/.
+          GOOS=linux GOARCH=arm64 go build -a -o dist/cmd-linux-arm64 ./cmd/.
+          GOOS=linux GOARCH=arm go build -a -o dist/cmd-linux-arm ./cmd/.
 
       - name: Build and push (if applicable)
         uses: docker/build-push-action@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,6 @@
-FROM golang:1.20-alpine as builder
-
-RUN apk --no-cache add make
-
-COPY . /app/
-WORKDIR /app/
-
-RUN make build
-
-
-FROM alpine:3.19.1
+FROM gcr.io/distroless/base-debian12:nonroot
 LABEL description="Kubernetes utility for exposing used image versions compared to the latest version, as metrics."
-
-RUN apk --no-cache add ca-certificates
-
-COPY --from=builder /app/bin/version-checker /usr/bin/version-checker
-
+ARG TARGETARCH
+ARG TARGETOS
+ADD dist/cmd-$TARGETOS-$TARGETARCH /usr/bin/version-checker
 ENTRYPOINT ["/usr/bin/version-checker"]

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:  ## display this help
 .PHONY: help build image all clean
 
 deps: ## Download all Dependencies
-	go mod download
+	go mod tidy
 
 test: deps ## test version-checker
 	go test ./... -coverprofile=coverage.out


### PR DESCRIPTION
0. Utilise github cache for golang modules
1. Build binaries outside of the container
2. Inject binaries into the distroless container
3. Ship the container
4. Profit.