### PR TITLE
Discard Tags older than that of what we believe to be latest

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -115,6 +115,12 @@ func latestSemver(opts *api.Options, tags []api.ImageTag) (*api.ImageTag, error)
 	for i := range tags {
 		v := semver.Parse(tags[i].Tag)
 
+		// If the image in question is "older" than the one we believe to be Latest
+		// Then we can ignore this image.
+		if latestV != nil && tags[i].Timestamp.After(latestImageTag.Timestamp) {
+			continue
+		}
+
 		// If regex enabled continue here.
 		// If we match, and is less than, update latest.
 		if opts.RegexMatcher != nil {


### PR DESCRIPTION
This brings the same/similar logic that's used within the Sha calculation logic, but into SemVer

The intention is to attempt to improve the SemVer verson discovery from bad dad.

Some repositories (and images) don't follow strict SemVersioning and / or include images for each commit/branch.
