### PR TITLE
Fixing GCR Client for GKE images which used to be hosted under `google-containers`

### DIFF
--- a/pkg/client/gcr/gcr.go
+++ b/pkg/client/gcr/gcr.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	lookupURL = "https://%s/v2/%s/%s/tags/list"
+	lookupURL = "https://%s/v2/%s/tags/list"
 )
 
 type Options struct {
@@ -48,11 +48,11 @@ func (c *Client) Name() string {
 }
 
 func (c *Client) Tags(ctx context.Context, host, repo, image string) ([]api.ImageTag, error) {
-	if repo == "google-containers" {
-		host = "gcr.io"
+	if repo != "" {
+		image = fmt.Sprintf("%s/%s", repo, image)
 	}
 
-	url := fmt.Sprintf(lookupURL, host, repo, image)
+	url := fmt.Sprintf(lookupURL, host, image)
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/pkg/client/gcr/path.go
+++ b/pkg/client/gcr/path.go
@@ -16,8 +16,9 @@ func (c *Client) IsHost(host string) bool {
 func (c *Client) RepoImageFromPath(path string) (string, string) {
 	lastIndex := strings.LastIndex(path, "/")
 
+	// If there's no slash, then its a "root" level image
 	if lastIndex == -1 {
-		return "google-containers", path
+		return "", path
 	}
 
 	return path[:lastIndex], path[lastIndex+1:]


### PR DESCRIPTION
This is related to https://github.com/jetstack/version-checker/issues/147

> Actually https://gcr.io/v2/google-containers/kube-proxy-amd64/tags/list hasn't been updated for a long time because they switched to https://gke.gcr.io/v2/kube-proxy-amd64/tags/list and new images are published there.

Google has now stopped pushing to `google-containers` namespace and now all gcr URI's can have multiple nested paths or none what so ever under their own vanity domain (gke.gcr.io)
