### PR TITLE
Start to document known configuration parameters for common image repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ enrich version checking on image tags:
     is. In this example, the current version of `my-container` will be compared
     against the image versions in the `docker.io/bitnami/etcd` registry.
 
+## Known configurations
+
+From time to time, version-checker may need some of the above options applied to determine the latest version,
+depending on how the maintainers publish their images. We are making a conscious effort to collate some of these configurations.
+
+See [known-configurations.md](known-configurations.md) for more details.
 
 ## Metrics
 

--- a/known-configurations.md
+++ b/known-configurations.md
@@ -1,0 +1,24 @@
+# Image Glossary
+
+This document serves as a reference for annotations required to be applied to various resources for the correct versions to be reported:
+
+## Images / Annotations
+
+### GKE Managed Images (kube-proxy, etc..)
+
+| Annotation | Reason |
+| `use-metadata.version-checker.io/kube-proxy="true"` | This is because many GKE images are suffixed as `v.1.26.5-gke.2700` for example. By Default, version-checker removes tags with metadata (`-XXXX`) as these traditionally relate to an Alpha or pre-release image. |
+
+### Grafana: docker.io/grafana/grafana
+
+Grafana has a few images, when version-checker looks up the version, it inadvertently records these tags as latest, enforcing a strict Semantic Version (without a prefix) prevents this.
+
+|Annotation |
+|`match-regex.version-checker.io/grafana='(\d+)\.(\d+)\.(\d+)'` |
+
+### Cert-Manager
+
+This is required as there's an image `608111629` which is detected as the latest, as Semver, this would equate to `608111629.0.0`.
+
+| Annotation |
+| `match-regex.version-checker.io/cert-manager='v(\d+)\.(\d+)\.(\d+)` |

--- a/known-configurations.md
+++ b/known-configurations.md
@@ -7,6 +7,7 @@ This document serves as a reference for annotations required to be applied to va
 ### GKE Managed Images (kube-proxy, etc..)
 
 | Annotation | Reason |
+|-|
 | `use-metadata.version-checker.io/kube-proxy="true"` | This is because many GKE images are suffixed as `v.1.26.5-gke.2700` for example. By Default, version-checker removes tags with metadata (`-XXXX`) as these traditionally relate to an Alpha or pre-release image. |
 
 ### Grafana: docker.io/grafana/grafana
@@ -14,6 +15,7 @@ This document serves as a reference for annotations required to be applied to va
 Grafana has a few images, when version-checker looks up the version, it inadvertently records these tags as latest, enforcing a strict Semantic Version (without a prefix) prevents this.
 
 |Annotation |
+|-|
 |`match-regex.version-checker.io/grafana='(\d+)\.(\d+)\.(\d+)'` |
 
 ### Cert-Manager
@@ -21,4 +23,5 @@ Grafana has a few images, when version-checker looks up the version, it inadvert
 This is required as there's an image `608111629` which is detected as the latest, as Semver, this would equate to `608111629.0.0`.
 
 | Annotation |
+|-|
 | `match-regex.version-checker.io/cert-manager='v(\d+)\.(\d+)\.(\d+)` |


### PR DESCRIPTION
This is an attempt to help the onboarding process of version-checker and introduces a list of images/repositories and any custom annotations needed on the pods.

This is after doing some extensive research, and determining that it is not feisable to attempt to address all the possible edgecases automatically
