### PR TITLE
Add Workload to nudge or clean up stale issues/MRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,32 @@
+name: 'Close stale issues and PRs'
+
+on:
+  schedule:
+  - cron: '21 1 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
+    runs-on: 'ubuntu-latest'
+    steps:
+    - uses: 'actions/stale@v9'
+      with:
+        stale-issue-message: |-
+          This issue has been automatically marked as stale because it has not had
+          any activity in the last 90 days. It will be closed if no further activity
+          occurs. Thank you for your contributions.
+        stale-issue-label: 'stale'
+        exempt-issue-labels: 'enhancement,security,pinned'
+
+        stale-pr-message: |-
+          This Pull Request is stale because it has been open for 60 days with
+          no activity. It will be closed in 7 days if no further activity.
+        stale-pr-label: 'stale'
+
+        days-before-stale: 90
+        days-before-close: 7


### PR DESCRIPTION
We love user feedback and contributions, but issues raised over 90 days likely get little to no response and are increadably challenging to debug some times.

Both responder and those watching will be notified when comment is added and respond with a message, those issues that require more work can be excluded too
