### PR TITLE
Add dockerconfigjson value to Helm chart

### DIFF
--- a/deploy/charts/version-checker/templates/deployment.yaml
+++ b/deploy/charts/version-checker/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
           - "--log-level={{.Values.versionChecker.logLevel}}"
           - "--metrics-serving-address={{.Values.versionChecker.metricsServingAddress}}"
           - "--test-all-containers={{.Values.versionChecker.testAllContainers}}"
+        volumeMounts:
+          - name: docker-config
+            mountPath: /docker
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         {{- with .Values.securityContext }}
@@ -72,6 +75,8 @@ spec:
               name: {{.Values.existingSecret}}
         {{- end }}
         env:
+        - name: DOCKER_CONFIG
+          value: /docker
         {{- if .Values.acr.refreshToken }}
         # ACR
         - name: VERSION_CHECKER_ACR_REFRESH_TOKEN
@@ -206,6 +211,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: docker-config
+          secret:
+            secretName: {{ include "version-checker.name" . }}-docker-config
+            items:
+              - key: .dockerconfigjson
+                path: config.json
         {{- if $secretEnabled }}
         - name: {{ include "version-checker.name" . }}
           secret:

--- a/deploy/charts/version-checker/templates/secret.yaml
+++ b/deploy/charts/version-checker/templates/secret.yaml
@@ -72,3 +72,13 @@ metadata:
 {{ include "version-checker.labels" . | indent 4 }}
 type: Opaque
 {{- end }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ (include "version-checker.name" .) }}-docker-config
+  labels:
+{{ include "version-checker.labels" . | indent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ .Values.dockerconfigjson | b64enc }}

--- a/deploy/charts/version-checker/values.yaml
+++ b/deploy/charts/version-checker/values.yaml
@@ -189,3 +189,15 @@ serviceMonitor:
   enabled: false
   # -- Additional labels to add to the ServiceMonitor
   additionalLabels: {}
+
+# -- Provide a raw docker config json. Makes it possible to configure the
+# authentication credentials used by the OCI client.
+dockerconfigjson: "{}"
+#dockerconfigjson: |
+#  {
+#  	"auths": {
+#  		"registry.example.com": {
+#  			"auth": "QXp1cmVEaWFtb25kOmh1bnRlcjI="
+#  		}
+#  	}
+#  }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,27 @@
+# Configuration
+
+This document describes how to configure version-checker.
+
+## Clients
+
+### OCI
+
+If there are no specific client implementations for the upstream registry
+provider, then version-checker will fallback to using a basic OCI client.
+
+You can configure authentication for specific registries by [setting credentials
+in Docker's config.json](https://github.com/google/go-containerregistry/blob/c195f151efe3369874c72662cd69ad43ee485128/pkg/authn/README.md#docker-config-auth).
+
+If you're using the Helm chart to deploy version-checker then you can set this
+with the `dockerconfigjson` value.
+
+```yaml
+dockerconfigjson: |
+  {
+  	"auths": {
+  		"registry.example.com": {
+  			"auth": "QXp1cmVEaWFtb25kOmh1bnRlcjI="
+  		}
+  	}
+  }
+```


### PR DESCRIPTION
This makes it possible to configure the credentials used by the fallback OCI client.