### PR TITLE
add the image timestamp as last_updated label

### DIFF
--- a/pkg/controller/checker/checker.go
+++ b/pkg/controller/checker/checker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -20,6 +21,7 @@ type Checker struct {
 type Result struct {
 	CurrentVersion string
 	LatestVersion  string
+	Timestamp      time.Time
 	IsLatest       bool
 	ImageURL       string
 }
@@ -100,6 +102,7 @@ func (c *Checker) handleSemver(ctx context.Context, imageURL, statusSHA, current
 	return &Result{
 		CurrentVersion: currentTag,
 		LatestVersion:  latestVersion,
+		Timestamp:      latestImage.Timestamp,
 		IsLatest:       isLatest,
 		ImageURL:       imageURL,
 	}, nil
@@ -168,7 +171,7 @@ func (c *Checker) isLatestSemver(ctx context.Context, imageURL, currentSHA strin
 	return latestImage, isLatest, nil
 }
 
-// isLatestSHA will return the the result of whether the given image is the latest, according to image SHA.
+// isLatestSHA will return the result of whether the given image is the latest, according to image SHA.
 func (c *Checker) isLatestSHA(ctx context.Context, imageURL, currentSHA string, opts *api.Options) (*Result, error) {
 	latestImage, err := c.search.LatestImage(ctx, imageURL, opts)
 	if err != nil {
@@ -184,6 +187,7 @@ func (c *Checker) isLatestSHA(ctx context.Context, imageURL, currentSHA string, 
 	return &Result{
 		CurrentVersion: currentSHA,
 		LatestVersion:  latestVersion,
+		Timestamp:      latestImage.Timestamp,
 		IsLatest:       isLatest,
 		ImageURL:       imageURL,
 	}, nil

--- a/pkg/controller/checker/checker_test.go
+++ b/pkg/controller/checker/checker_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/aws/smithy-go/time"
+
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 
@@ -27,6 +29,23 @@ func TestContainer(t *testing.T) {
 			opts:       nil,
 			searchResp: nil,
 			expResult:  nil,
+		},
+		"use timestamp from image as last-updated": {
+			statusSHA: "localhost:5000/version-checker@sha:123",
+			imageURL:  "localhost:5000/version-checker:v0.2.0",
+			opts:      new(api.Options),
+			searchResp: &api.ImageTag{
+				Tag:       "v0.2.0",
+				SHA:       "sha:456",
+				Timestamp: time.ParseEpochSeconds(12345678),
+			},
+			expResult: &Result{
+				CurrentVersion: "v0.2.0@sha:123",
+				LatestVersion:  "v0.2.0@sha:456",
+				ImageURL:       "localhost:5000/version-checker",
+				IsLatest:       false,
+				Timestamp:      time.ParseEpochSeconds(12345678),
+			},
 		},
 		"if v0.2.0 is latest version, but different sha, then not latest": {
 			statusSHA: "localhost:5000/version-checker@sha:123",

--- a/pkg/controller/internal/fake/search/search.go
+++ b/pkg/controller/internal/fake/search/search.go
@@ -11,18 +11,33 @@ import (
 var _ search.Searcher = &FakeSearch{}
 
 type FakeSearch struct {
+	imageF       func() (*api.ImageTag, error)
 	latestImageF func() (*api.ImageTag, error)
 }
 
 func New() *FakeSearch {
 	return &FakeSearch{
+		imageF: func() (*api.ImageTag, error) {
+			return nil, nil
+		},
 		latestImageF: func() (*api.ImageTag, error) {
 			return nil, nil
 		},
 	}
 }
 
-func (f *FakeSearch) With(image *api.ImageTag, err error) *FakeSearch {
+func (f *FakeSearch) WithImage(image *api.ImageTag, err error) *FakeSearch {
+	f.imageF = func() (*api.ImageTag, error) {
+		return image, err
+	}
+	return f
+}
+
+func (f *FakeSearch) Image(context.Context, string, string, string, bool) (*api.ImageTag, error) {
+	return f.imageF()
+}
+
+func (f *FakeSearch) WithLatestImage(image *api.ImageTag, err error) *FakeSearch {
 	f.latestImageF = func() (*api.ImageTag, error) {
 		return image, err
 	}

--- a/pkg/controller/sync.go
+++ b/pkg/controller/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -97,6 +98,7 @@ func (c *Controller) checkContainer(ctx context.Context, log *logrus.Entry, pod 
 		container.Name, containerType,
 		result.ImageURL, result.IsLatest,
 		result.CurrentVersion, result.LatestVersion,
+		result.Timestamp.Format(time.DateOnly),
 	)
 
 	return nil

--- a/pkg/controller/sync.go
+++ b/pkg/controller/sync.go
@@ -98,7 +98,7 @@ func (c *Controller) checkContainer(ctx context.Context, log *logrus.Entry, pod 
 		container.Name, containerType,
 		result.ImageURL, result.IsLatest,
 		result.CurrentVersion, result.LatestVersion,
-		result.Timestamp.Format(time.DateOnly),
+		result.CurrentTimestamp.Format(time.DateOnly),
 	)
 
 	return nil

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -44,7 +44,7 @@ func New(log *logrus.Entry) *Metrics {
 			Help:      "Where the container in use is using the latest upstream registry version",
 		},
 		[]string{
-			"namespace", "pod", "container", "container_type", "image", "current_version", "latest_version",
+			"namespace", "pod", "container", "container_type", "image", "current_version", "latest_version", "last_updated",
 		},
 	)
 
@@ -87,7 +87,7 @@ func (m *Metrics) Run(servingAddress string) error {
 	return nil
 }
 
-func (m *Metrics) AddImage(namespace, pod, container, containerType, imageURL string, isLatest bool, currentVersion, latestVersion string) {
+func (m *Metrics) AddImage(namespace, pod, container, containerType, imageURL string, isLatest bool, currentVersion, latestVersion, lastUpdated string) {
 	// Remove old image url/version if it exists
 	m.RemoveImage(namespace, pod, container, containerType)
 
@@ -100,7 +100,7 @@ func (m *Metrics) AddImage(namespace, pod, container, containerType, imageURL st
 	}
 
 	m.containerImageVersion.With(
-		m.buildLabels(namespace, pod, container, containerType, imageURL, currentVersion, latestVersion),
+		m.buildLabels(namespace, pod, container, containerType, imageURL, currentVersion, latestVersion, lastUpdated),
 	).Set(isLatestF)
 
 	index := m.latestImageIndex(namespace, pod, container, containerType)
@@ -131,7 +131,7 @@ func (m *Metrics) latestImageIndex(namespace, pod, container, containerType stri
 	return strings.Join([]string{namespace, pod, container, containerType}, "")
 }
 
-func (m *Metrics) buildLabels(namespace, pod, container, containerType, imageURL, currentVersion, latestVersion string) prometheus.Labels {
+func (m *Metrics) buildLabels(namespace, pod, container, containerType, imageURL, currentVersion, latestVersion, lastUpdated string) prometheus.Labels {
 	return prometheus.Labels{
 		"namespace":       namespace,
 		"pod":             pod,
@@ -140,6 +140,7 @@ func (m *Metrics) buildLabels(namespace, pod, container, containerType, imageURL
 		"image":           imageURL,
 		"current_version": currentVersion,
 		"latest_version":  latestVersion,
+		"last_updated":    lastUpdated,
 	}
 }
 

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -8,17 +8,21 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	epoch = "1970-01-01"
+)
+
 func TestCache(t *testing.T) {
 	m := New(logrus.NewEntry(logrus.New()))
 
 	for i, typ := range []string{"init", "container"} {
 		version := fmt.Sprintf("0.1.%d", i)
-		m.AddImage("namespace", "pod", "container", typ, "url", true, version, version)
+		m.AddImage("namespace", "pod", "container", typ, "url", true, version, version, epoch)
 	}
 
 	for i, typ := range []string{"init", "container"} {
 		version := fmt.Sprintf("0.1.%d", i)
-		mt, _ := m.containerImageVersion.GetMetricWith(m.buildLabels("namespace", "pod", "container", typ, "url", version, version))
+		mt, _ := m.containerImageVersion.GetMetricWith(m.buildLabels("namespace", "pod", "container", typ, "url", version, version, epoch))
 		count := testutil.ToFloat64(mt)
 		if count != 1 {
 			t.Error("Should have added metric")
@@ -30,7 +34,7 @@ func TestCache(t *testing.T) {
 	}
 	for i, typ := range []string{"init", "container"} {
 		version := fmt.Sprintf("0.1.%d", i)
-		mt, _ := m.containerImageVersion.GetMetricWith(m.buildLabels("namespace", "pod", "container", typ, "url", version, version))
+		mt, _ := m.containerImageVersion.GetMetricWith(m.buildLabels("namespace", "pod", "container", typ, "url", version, version, epoch))
 		count := testutil.ToFloat64(mt)
 		if count != 0 {
 			t.Error("Should have removed metric")

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,14 +41,22 @@ func (v *Version) Run(refreshRate time.Duration) {
 	v.imageCache.StartGarbageCollector(refreshRate)
 }
 
+// AllTagsFromImage will return all tags given an imageURL.
+func (v *Version) AllTagsFromImage(ctx context.Context, imageURL string) ([]api.ImageTag, error) {
+	if tagsI, err := v.imageCache.Get(ctx, imageURL, imageURL, nil); err != nil {
+		return nil, err
+	} else {
+		return tagsI.([]api.ImageTag), err
+	}
+}
+
 // LatestTagFromImage will return the latest tag given an imageURL, according
 // to the given options.
 func (v *Version) LatestTagFromImage(ctx context.Context, imageURL string, opts *api.Options) (*api.ImageTag, error) {
-	tagsI, err := v.imageCache.Get(ctx, imageURL, imageURL, nil)
+	tags, err := v.AllTagsFromImage(ctx, imageURL)
 	if err != nil {
 		return nil, err
 	}
-	tags := tagsI.([]api.ImageTag)
 
 	var tag *api.ImageTag
 


### PR DESCRIPTION
In our use case we have many images and we'd like to be able to prioritize better. In order to sort by oldest image, this PR adds a `last_updated` label (using the Timestamp info on the image).