### PR TITLE
add --image-url-substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ enrich version checking on image tags:
     used to change the URL for where to lookup where the latest image version
     is. In this example, the current version of `my-container` will be compared
     against the image versions in the `docker.io/bitnami/etcd` registry.
+    (This also overrrides any substitution/replacement from `--image-url-substitution`.)
 
 ## Known configurations
 

--- a/cmd/app/options.go
+++ b/cmd/app/options.go
@@ -65,6 +65,7 @@ type Options struct {
 	MetricsServingAddress string
 	DefaultTestAll        bool
 	CacheTimeout          time.Duration
+	ImageURLSubstitution  string
 	LogLevel              string
 
 	kubeConfigFlags *genericclioptions.ConfigFlags
@@ -113,6 +114,14 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 		"image-cache-timeout", "c", time.Minute*30,
 		"The time for an image version in the cache to be considered fresh. Images "+
 			"will be rechecked after this interval.")
+
+	fs.StringVarP(&o.ImageURLSubstitution,
+		"image-url-substitution", "", "",
+		"Image URL substitution. In case you want to apply a replacement to all image URLs. "+
+			"E.g. when you mirrored them and want to check the originals. "+
+			"The format follows the sed substitution command syntax. "+
+			"E.g. s#myacr.azurecr.io/mirror/##g to remove your registry from: myacr.azurecr.io/mirror/docker.io/alpine:3"+
+			"(Any override-url.version-checker.io/my-container annotation would still override everything afterwards.)")
 
 	fs.StringVarP(&o.LogLevel,
 		"log-level", "v", "info",

--- a/pkg/controller/checker/substitution.go
+++ b/pkg/controller/checker/substitution.go
@@ -1,0 +1,59 @@
+package checker
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type Substitution struct {
+	Pattern    *regexp.Regexp
+	Substitute string
+	All        bool
+}
+
+func NewSubstitutionFromSedCommand(sedCommand string) (*Substitution, error) {
+	pattern, substitute, flags, err := splitSedSubstitutionCommand(sedCommand)
+	if err != nil {
+		return nil, err
+	}
+	compiledPattern, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("sed command for substitution has regex that does not compile: %s %w", pattern, err)
+	}
+	var all bool
+	if flags == "g" {
+		all = true
+	} else if flags != "" {
+		return nil, fmt.Errorf("sed command for substitution only supports the 'g' flag: %s", flags)
+	}
+
+	return &Substitution{
+		Pattern:    compiledPattern,
+		Substitute: substitute,
+		All:        all,
+	}, nil
+}
+
+func splitSedSubstitutionCommand(sedCommand string) (string, string, string, error) {
+	if len(sedCommand) < 4 {
+		return "", "", "", fmt.Errorf("sed command for substitution seems to short: %s", sedCommand)
+	}
+	if sedCommand[0] != 's' {
+		return "", "", "", fmt.Errorf("sed command for substitution should start with s: %s", sedCommand)
+	}
+	separator := regexp.QuoteMeta(sedCommand[1:2])
+	group := fmt.Sprintf(`((?:.|\\[%s])*)`, separator)
+	pattern := `^s` + separator + group + separator + group + separator + group + `$`
+	matcher, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", "", "", fmt.Errorf("regexp to parse sed command for substitution does not compile: %s %w", pattern, err)
+	}
+	submatches := matcher.FindStringSubmatch(sedCommand)
+	if len(submatches) != 4 {
+		return "", "", "", fmt.Errorf("sed command for substitution could not be parsed: %s", pattern)
+	}
+	return strings.ReplaceAll(submatches[1], "\\"+separator, separator),
+		strings.ReplaceAll(submatches[2], "\\"+separator, separator),
+		submatches[3], nil
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -51,6 +51,7 @@ func New(
 	kubeClient kubernetes.Interface,
 	log *logrus.Entry,
 	defaultTestAll bool,
+	imageURLSubstitution *checker.Substitution,
 ) *Controller {
 	workqueue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]())
 	scheduledWorkQueue := scheduler.NewScheduledWorkQueue(clock.RealClock{}, workqueue.Add)
@@ -58,6 +59,7 @@ func New(
 	log = log.WithField("module", "controller")
 	versionGetter := version.New(log, imageClient, cacheTimeout)
 	search := search.New(log, cacheTimeout, versionGetter)
+	checker := checker.New(search, imageURLSubstitution)
 
 	c := &Controller{
 		log:                log,
@@ -65,7 +67,7 @@ func New(
 		workqueue:          workqueue,
 		scheduledWorkQueue: scheduledWorkQueue,
 		metrics:            metrics,
-		checker:            checker.New(search),
+		checker:            checker,
 		defaultTestAll:     defaultTestAll,
 	}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -30,7 +30,7 @@ func TestNewController(t *testing.T) {
 	metrics := &metrics.Metrics{}
 	imageClient := &client.Client{}
 
-	controller := New(5*time.Minute, metrics, imageClient, kubeClient, testLogger, true)
+	controller := New(5*time.Minute, metrics, imageClient, kubeClient, testLogger, true, nil)
 
 	assert.NotNil(t, controller)
 	assert.Equal(t, controller.defaultTestAll, true)
@@ -43,7 +43,7 @@ func TestRun(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset()
 	metrics := &metrics.Metrics{}
 	imageClient := &client.Client{}
-	controller := New(5*time.Minute, metrics, imageClient, kubeClient, testLogger, true)
+	controller := New(5*time.Minute, metrics, imageClient, kubeClient, testLogger, true, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -72,7 +72,7 @@ func TestAddObject(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset()
 	metrics := &metrics.Metrics{}
 	imageClient := &client.Client{}
-	controller := New(5*time.Minute, metrics, imageClient, kubeClient, testLogger, true)
+	controller := New(5*time.Minute, metrics, imageClient, kubeClient, testLogger, true, nil)
 
 	obj := &corev1.Pod{}
 	controller.addObject(obj)
@@ -99,7 +99,7 @@ func TestDeleteObject(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset()
 	metrics := &metrics.Metrics{}
 	imageClient := &client.Client{}
-	controller := New(5*time.Minute, metrics, imageClient, kubeClient, testLogger, true)
+	controller := New(5*time.Minute, metrics, imageClient, kubeClient, testLogger, true, nil)
 
 	pod := &corev1.Pod{
 		Spec: corev1.PodSpec{
@@ -120,7 +120,7 @@ func TestProcessNextWorkItem(t *testing.T) {
 	kubeClient := fake.NewSimpleClientset()
 	metrics := &metrics.Metrics{}
 	imageClient := &client.Client{}
-	controller := New(5*time.Minute, metrics, imageClient, kubeClient, testLogger, true)
+	controller := New(5*time.Minute, metrics, imageClient, kubeClient, testLogger, true, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/controller/sync_test.go
+++ b/pkg/controller/sync_test.go
@@ -25,7 +25,7 @@ func TestController_Sync(t *testing.T) {
 	metrics := &metrics.Metrics{}
 	imageClient := &client.Client{}
 	searcher := search.New(log, 5*time.Minute, version.New(log, imageClient, 5*time.Minute))
-	checker := checker.New(searcher)
+	checker := checker.New(searcher, nil)
 
 	controller := &Controller{
 		log:            log,
@@ -59,7 +59,7 @@ func TestController_SyncContainer(t *testing.T) {
 	metrics := &metrics.Metrics{}
 	imageClient := &client.Client{}
 	searcher := search.New(log, 5*time.Minute, version.New(log, imageClient, 5*time.Minute))
-	checker := checker.New(searcher)
+	checker := checker.New(searcher, nil)
 
 	controller := &Controller{
 		log:            log,
@@ -90,7 +90,7 @@ func TestController_CheckContainer(t *testing.T) {
 	metrics := &metrics.Metrics{}
 	imageClient := &client.Client{}
 	searcher := search.New(log, 5*time.Minute, version.New(log, imageClient, 5*time.Minute))
-	checker := checker.New(searcher)
+	checker := checker.New(searcher, nil)
 
 	controller := &Controller{
 		log:            log,
@@ -118,7 +118,7 @@ func TestController_SyncContainer_NoVersionFound(t *testing.T) {
 	metrics := &metrics.Metrics{}
 	imageClient := &client.Client{}
 	searcher := search.New(log, 5*time.Minute, version.New(log, imageClient, 5*time.Minute))
-	checker := checker.New(searcher)
+	checker := checker.New(searcher, nil)
 
 	controller := &Controller{
 		log:            log,


### PR DESCRIPTION
In our use case we are mirroring external/public images (e.g. from DockerHub) that we use to our own private container registry, so we don't have to rely on availability and rate limiting. But we only mirror particular/arbitrary tags. So version-checker will always see those as the latest tags. This PR adds a `--image-url-substitution` cli option. It enables to replace (`sed`-style) something in all image URLs. All our mirrored images are prefixed like `privateregistry.example.com/mirrored/docker.io/original:tag`, so we can remove that prefix.