### PR TITLE
Enable automated release tagging when PR from branch's 'release-xxxx'

### DIFF
--- a/.github/workflows/release-tagger.yaml
+++ b/.github/workflows/release-tagger.yaml
@@ -1,0 +1,23 @@
+name: Tag Release
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  TagRelease:
+    permissions:
+      contents: write
+    name: Create Release Tag
+    runs-on: ubuntu-22.04
+    if: github.event.pull_request.merged == true && startsWith( github.event.pull_request.head.ref, 'release-' )
+    steps:
+      - uses: bhowell2/github-substring-action@1.0.2
+        id: release_number
+        with:
+          value: ${{ github.event.pull_request.head.ref }}
+          index_of_str: "release-"
+      - name: Create Tag
+        uses: tvdias/github-tagger@v0.0.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.release_number.outputs.substring }}


### PR DESCRIPTION
This is a quality of life for maintainers.

Once a PR from a branch `release-xxxx` is merged, this workload will push a tag from the `vx.x.x`.

This will then trigger the full release workflow publishing the chart and container images.

Edit: I've been using this on another internal project and its been working great! 👍 
