### PR TITLE
Adding support for additional ACR TLD's

### DIFF
--- a/pkg/client/acr/path.go
+++ b/pkg/client/acr/path.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	reg = regexp.MustCompile(`^.*\.azurecr.io$`)
+	reg = regexp.MustCompile(`.*\.azurecr\.io|.*\.azurecr\.cn|.*\.azurecr\.de|.*\.azurecr\.us`)
 )
 
 func (c *Client) IsHost(host string) bool {

--- a/pkg/client/acr/path_test.go
+++ b/pkg/client/acr/path_test.go
@@ -27,6 +27,18 @@ func TestIsHost(t *testing.T) {
 			host:  "versionchecker.azurecr.io",
 			expIs: true,
 		},
+		"azurecr.cn with random sub domains should be true": {
+			host:  "versionchecker.azurecr.cn",
+			expIs: true,
+		},
+		"azurecr.de with random sub domains should be true": {
+			host:  "versionchecker.azurecr.de",
+			expIs: true,
+		},
+		"azurecr.us with random sub domains should be true": {
+			host:  "versionchecker.azurecr.us",
+			expIs: true,
+		},
 		"foodazurecr.io should be false": {
 			host:  "fooazurecr.io",
 			expIs: false,


### PR DESCRIPTION
This add's some additional TLD's that are valid azure container registries for various regions
