### PR TITLE
Adding a LastUpdated metric so that we can see when images were lookedup and if we have stale data

### DIFF
--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -33,7 +33,7 @@ func TestCache(t *testing.T) {
 
 	// as well as the lastUpdated...
 	for _, typ := range []string{"init", "container"} {
-		mt, err := m.containerImageUpdated.GetMetricWith(m.buildLastUpdatedLabels("namespace", "pod", "container", typ, "url"))
+		mt, err := m.containerImageChecked.GetMetricWith(m.buildLastUpdatedLabels("namespace", "pod", "container", typ, "url"))
 		require.NoError(t, err)
 		count := testutil.ToFloat64(mt)
 		assert.GreaterOrEqual(t, count, float64(time.Now().Unix()))
@@ -53,7 +53,7 @@ func TestCache(t *testing.T) {
 	}
 	// And the Last Updated is removed too
 	for _, typ := range []string{"init", "container"} {
-		mt, err := m.containerImageUpdated.GetMetricWith(m.buildLastUpdatedLabels("namespace", "pod", "container", typ, "url"))
+		mt, err := m.containerImageChecked.GetMetricWith(m.buildLastUpdatedLabels("namespace", "pod", "container", typ, "url"))
 		require.NoError(t, err)
 		count := testutil.ToFloat64(mt)
 		assert.Equal(t, count, float64(0))

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sirupsen/logrus"
-  
-	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCache(t *testing.T) {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -3,37 +3,57 @@ package metrics
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sirupsen/logrus"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCache(t *testing.T) {
 	m := NewServer(logrus.NewEntry(logrus.New()))
 
+	// Lets add some Images/Metrics...
 	for i, typ := range []string{"init", "container"} {
 		version := fmt.Sprintf("0.1.%d", i)
 		m.AddImage("namespace", "pod", "container", typ, "url", true, version, version)
 	}
 
+	// Check and ensure that the metrics are available...
 	for i, typ := range []string{"init", "container"} {
 		version := fmt.Sprintf("0.1.%d", i)
-		mt, _ := m.containerImageVersion.GetMetricWith(m.buildLabels("namespace", "pod", "container", typ, "url", version, version))
+		mt, err := m.containerImageVersion.GetMetricWith(m.buildFullLabels("namespace", "pod", "container", typ, "url", version, version))
+		require.NoError(t, err)
 		count := testutil.ToFloat64(mt)
-		if count != 1 {
-			t.Error("Should have added metric")
-		}
+		require.Equal(t, count, float64(1))
 	}
 
+	// as well as the lastUpdated...
+	for _, typ := range []string{"init", "container"} {
+		mt, err := m.containerImageUpdated.GetMetricWith(m.buildLastUpdatedLabels("namespace", "pod", "container", typ, "url"))
+		require.NoError(t, err)
+		count := testutil.ToFloat64(mt)
+		require.GreaterOrEqual(t, count, float64(time.Now().Unix()))
+	}
+
+	// Remove said metrics...
 	for _, typ := range []string{"init", "container"} {
 		m.RemoveImage("namespace", "pod", "container", typ)
 	}
+	// Ensure metrics and values return 0
 	for i, typ := range []string{"init", "container"} {
 		version := fmt.Sprintf("0.1.%d", i)
-		mt, _ := m.containerImageVersion.GetMetricWith(m.buildLabels("namespace", "pod", "container", typ, "url", version, version))
+		mt, err := m.containerImageVersion.GetMetricWith(m.buildFullLabels("namespace", "pod", "container", typ, "url", version, version))
+		require.NoError(t, err)
 		count := testutil.ToFloat64(mt)
-		if count != 0 {
-			t.Error("Should have removed metric")
-		}
+		require.Equal(t, count, float64(0))
+	}
+	// And the Last Updated is removed too
+	for _, typ := range []string{"init", "container"} {
+		mt, err := m.containerImageUpdated.GetMetricWith(m.buildLastUpdatedLabels("namespace", "pod", "container", typ, "url"))
+		require.NoError(t, err)
+		count := testutil.ToFloat64(mt)
+		require.Equal(t, count, float64(0))
 	}
 }


### PR DESCRIPTION
This is a re-work of #287 - in which we define a new metric for the last updated value, we use the same set of labels so that events can be corrolated, this should also ensure the we don't have any stale data
