### PR TITLE
Report Errors up to reconcile, so that we can track better

### DIFF
--- a/pkg/controller/pod_controller.go
+++ b/pkg/controller/pod_controller.go
@@ -74,14 +74,14 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{Requeue: false}, nil
 	}
 	if err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{RequeueAfter: (r.RequeueDuration / 2)}, err
 	}
 
 	// Perform the version check (your sync logic)
 	if err := r.sync(ctx, pod); err != nil {
 		log.Error(err, "Failed to process pod")
 		// Requeue after some time in case of failure
-		return ctrl.Result{RequeueAfter: (r.RequeueDuration / 2)}, nil
+		return ctrl.Result{RequeueAfter: (r.RequeueDuration / 2)}, err
 	}
 
 	// Schedule next check

--- a/pkg/controller/pod_sync.go
+++ b/pkg/controller/pod_sync.go
@@ -66,8 +66,7 @@ func (c *PodReconciler) syncContainer(ctx context.Context,
 	err = c.checkContainer(ctx, log, pod, container, containerType, opts)
 	// Don't re-sync, if no version found meeting search criteria
 	if versionerrors.IsNoVersionFound(err) {
-		log.Error(err.Error())
-		return nil
+		return err
 	}
 	if err != nil {
 		return fmt.Errorf("failed to check container image %q: %s",


### PR DESCRIPTION
This allows the use of the `controller_runtime_reconcile_errors_total` metric to report errors, we still continue to requeue.
