### PR TITLE
Fix broken link for `known-configurations.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ available to view the image versions as a table.
 From time to time, version-checker may need some of the above options applied to determine the latest version,
 depending on how the maintainers publish their images. We are making a conscious effort to collate some of these configurations.
 
-See [known-configurations.md](../known-configurations.md) for more details.
+See [known-configurations.md](./known-configurations.md) for more details.


### PR DESCRIPTION
The main link from `README.md` is using a wrong reference to `known-configurations.md`