### PR TITLE
Fix retryablehttp logging adapter for docker/quay clients

### DIFF
--- a/pkg/client/docker/docker.go
+++ b/pkg/client/docker/docker.go
@@ -70,7 +70,7 @@ func New(opts Options, log *logrus.Entry) (*Client, error) {
 	retryclient.RetryWaitMin = 1 * time.Second
 	// This custom backoff will fail requests that have a max wait of the RetryWaitMax
 	retryclient.Backoff = util.HTTPBackOff
-	retryclient.Logger = leveledlogger.Logger{Entry: log.WithField("client", "docker")}
+	retryclient.Logger = &leveledlogger.Logger{Entry: log.WithField("client", "docker")}
 	client := retryclient.StandardClient()
 
 	// Setup Auth if username and password used.

--- a/pkg/client/quay/quay.go
+++ b/pkg/client/quay/quay.go
@@ -40,7 +40,7 @@ func New(opts Options, log *logrus.Entry) *Client {
 	if opts.Transporter != nil {
 		client.HTTPClient.Transport = opts.Transporter
 	}
-	client.Logger = leveledlogger.Logger{Entry: log.WithField("client", "quay")}
+	client.Logger = &leveledlogger.Logger{Entry: log.WithField("client", "quay")}
 
 	return &Client{
 		Options: opts,


### PR DESCRIPTION
Fix the adapter that hooks retryablehttp into the logger version-checker
uses by passing a pointer to a leveledlogger, so that configured log
levels are honoured.

The adapter was added in b6ae308390 (Track Kubernetes Channels for
latest versions) and used correctly there, but the docker and quay
clients pass a non-pointer leveledlogger to retryablehttp. Its methods
have pointer receivers, so they are not in the value's method set and it
does not satisfy retryablehttp's LeveledLogger interface. retryablehttp
then falls back to the Printf-based Logger, which logs at info level
regardless of the configured level.
